### PR TITLE
Add release notes for emulator v0.5.0 and v0.5.1

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # Flow CLI
 
-> Version 0.4.0
+> Version 0.5.1
 
 The Flow CLI is a command-line interface that provides useful utilities for building Flow applications.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,16 @@ Simply re-run the installation commands above.
 
 # Changelog
 
+## Version 0.5.1
+
+- Upgraded Cadence to [v0.5.1](https://github.com/onflow/cadence/releases/tag/v0.5.1)
+- Upgraded Flow Emulator to [v0.5.1](https://github.com/onflow/flow/blob/master/docs/emulator.md#version-051)
+
+## Version 0.5.0
+
+- Upgraded Cadence to [v0.5.0](https://github.com/onflow/cadence/releases/tag/v0.5.0)
+- Upgraded Flow Emulator to [v0.5.0](https://github.com/onflow/flow/blob/master/docs/emulator.md#version-050)
+
 ## Version 0.4.0
 
 - Upgraded Cadence to [v0.4.0](https://github.com/onflow/cadence/releases/tag/v0.4.0)

--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -112,6 +112,85 @@ flow keys generate
 
 # Changelog
 
+## Version 0.5.1
+
+### SDK Compatibility
+
+| Flow Go SDK v0.6.0 | Flow Go SDK v0.7.0 | Flow Go SDK v0.7.1 |
+|--|--|--|
+|❌|✅|✅|
+
+### 🐞 Bug Fixes
+
+- Upgrade to Cadence `v0.5.1`: https://github.com/onflow/cadence/releases/tag/v0.5.1
+
+### ⚙️ Installing & Upgrading
+
+#### Flow CLI
+
+This version of the emulator is included in v0.5.1 of the [Flow CLI](./cli.md).
+
+#### Docker
+
+```
+docker run -p 3569:3569 gcr.io/dl-flow/emulator:v0.5.1
+```
+
+---
+
+## Version 0.5.0
+
+### SDK Compatibility
+
+| Flow Go SDK v0.6.0 | Flow Go SDK v0.7.0 | Flow Go SDK v0.7.1 |
+|--|--|--|
+|❌|✅|✅|
+
+### 💥  Breaking Changes
+
+#### Cadence v0.5.0
+
+The emulator has been upgraded to use the latest Cadence release. Please view the Cadence release notes for an overview of the features and changes introduced in this release: https://github.com/onflow/cadence/releases/tag/v0.5.0
+
+**Byte Array Literals**
+
+Cadence now represents all byte arrays as `[UInt8]` rather than `[Int]`. This affects the following functions:
+
+- `AuthAccount.addPublicKey(publicKey: [Int])` => `AuthAccount.addPublicKey(publicKey: [UInt8])` 
+- `AuthAccount.setCode(code: [Int])` => `AuthAccount.setCode(code: [UInt8])`
+
+However, array literals such as the following will still be inferred as `[Int]`, meaning that they can't be used directly:
+
+```
+myAccount.addPublicKey([1, 2, 3])
+```
+
+There are two recommended workarounds:
+- Pass byte arrays as hexadecimal strings and decode in Cadence [JS Example](https://github.com/onflow/flow-js-sdk/blob/master/packages/six-create-account/src/six-create-account.js#L10-L18)
+- Pass byte arrays as transaction arguments typed as `[UInt8]` [Go Example](https://github.com/onflow/flow-go-sdk/blob/master/templates/accounts.go#L28-L63)
+
+#### Data storage format
+
+The underlying data format used for persistent storage has changed from `gob` encoding to CBOR (https://github.com/dapperlabs/flow-emulator/pull/72). This means that existing persisted data will not be compatible with `v0.5.0` onwards.
+
+### ⭐ Features
+
+- The `ExecuteScriptAtLatestBlock`, `ExecuteScriptAtBlockHeight`, and `ExecuteScriptAtBlockID` methods now accept script arguments [Go Example](https://github.com/onflow/flow-go-sdk/blob/master/examples/user_signature/main.go#L149-L160)
+
+### ⚙️ Installing & Upgrading
+
+#### Flow CLI
+
+This version of the emulator is included in v0.5.0 of the [Flow CLI](./cli.md).
+
+#### Docker
+
+```
+docker run -p 3569:3569 gcr.io/dl-flow/emulator:v0.5.0
+```
+
+---
+
 ## Version 0.4.0
 
 ### 💥 Breaking Changes

--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -1,6 +1,6 @@
 # Flow Emulator
 
-> Version 0.4.0
+> Version 0.5.1
 
 The Flow Emulator is a lightweight tool that emulates
 the behaviour of the real Flow network.


### PR DESCRIPTION
This PR adds release notes for `v0.5.0` and `v0.5.1` of both the emulator and CLI.