### PR TITLE
Documentation for Cadence downstream dependencies / releasing the CLI

### DIFF
--- a/docs/development/cadence-downstream-dependencies.md
+++ b/docs/development/cadence-downstream-dependencies.md
@@ -1,4 +1,4 @@
-# Updating the Cadence Downstream Dependencies
+# Updating the Cadence Downstream Dependencies / Releasing the CLI
 
 Updating the Cadence downstream dependencies should be done in the following steps:
 
@@ -29,3 +29,7 @@ Updating the Cadence downstream dependencies should be done in the following ste
    - Update `github.com/dapperlabs/flow-emulator` to the new release
    - Update `github.com/onflow/flow-go-sdk` to the new release
    - Tag a new release and push it
+   - Run `make versioned-binaries` to build the binaries
+   - Upload the binaries (`cmd/flow/flow-*`) to https://console.cloud.google.com/storage/browser/flow-cli/?project=dl-flow&authuser=0
+   - Change the contents of `version.txt` in the bucket to `vX.X.X`
+   

--- a/docs/development/cadence-downstream-dependencies.md
+++ b/docs/development/cadence-downstream-dependencies.md
@@ -1,0 +1,31 @@
+# Updating the Cadence Downstream Dependencies
+
+Updating the Cadence downstream dependencies should be done in the following steps:
+
+1. Update [Flow Go](https://github.com/dapperlabs/flow-go):
+   - Update to the latest Cadence version by running the following command in both the root directory and in `integration` (replace `X.X.X` with the version number):
+     ```sh
+     $ go get github.com/onflow/cadence@vX.X.X 
+     ```
+     
+2. Update [Flow Go SDK](https://github.com/onflow/flow-go-sdk):
+   - Update `github.com/onflow/cadence` to the new release
+   - Tag a new release and push it
+   
+3. Update the [Flow Emulator](https://github.com/dapperlabs/flow-emulator):
+   - Update `github.com/dapperlabs/flow-go` to the latest commit
+   - Update `github.com/onflow/flow-go-sdk` to the new release
+   - Update `github.com/onflow/cadence` to the new release
+   - Tag a new release and push it
+   
+4. Update the [Cadence Language Server](https://github.com/onflow/cadence/tree/master/languageserver):
+   - Update `github.com/onflow/flow-go-sdk` to the new release
+   - Update `github.com/onflow/cadence` to the new release
+   - Tag a new release as `languageserver/vX.X.X` and push it
+
+5. Update the [Flow CLI](github.com/dapperlabs/flow-cli):
+   - Update `github.com/onflow/cadence` to the new release
+   - Update `github.com/onflow/cadence/languageserver` to the new release
+   - Update `github.com/dapperlabs/flow-emulator` to the new release
+   - Update `github.com/onflow/flow-go-sdk` to the new release
+   - Tag a new release and push it


### PR DESCRIPTION
Document how to update the downstream dependencies of Cadence and how to release the CLI