### PR TITLE
Initial proposal for RFC process

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,101 @@
+# Flow version compatibility
+
+This document outlines the compatibility practices used when releasing new versions of the Flow protocol, APIs and tools. 
+
+## Semantic versioning
+
+Flow follows Semantic Versioning 2.0 (semver) for all components and projects. Each release version 
+of Flow has the form MAJOR.MINOR.PATCH. For example, Flow Protocol version 1.2.3 has MAJOR version 1, MINOR version 2, and PATCH version 3. Changes to each number have the following meaning:
+
+- **MAJOR:** Potentially backwards incompatible changes. Code and data that worked with a previous major release will not necessarily work with the new release.
+
+- **MINOR:** Backwards compatible features, speed improvements, etc. Code and data that worked with a previous minor release and which depends only on the public API will continue to work unchanged. For details on what is and is not the public API, see [Public APIs](#public-apis).
+
+- **PATCH:** Backwards compatible bug fixes.
+
+For example, release 1.0.0 introduced backwards incompatible changes from release 0.12.1. However, release 1.1.1 was backwards compatible with release 1.0.0.
+
+## Public APIs
+
+Each Flow component exposes a public API, loosely defined as the functionality that it exposes to other components or users.
+
+<table>
+    <thead>
+        <tr>
+            <th>Component</th>
+            <th>Subcomponent</th>
+            <th>Public API(s)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan=5>Flow Protocol</td>
+            <td>Collection Node</td>
+            <td>
+              Ingestion Engine<br/>
+              Proposal Engine<br/>
+              Pusher Engine<br/>
+              Collection RPC API
+            </td>
+        </tr>
+        <tr>
+            <td>Consensus Node</td>
+            <td>
+              Ingestion Engine<br/>
+              Provider Engine<br/>
+              Matching Engine<br/>
+              Compliance Engine
+            </td>
+        </tr>
+        <tr>
+            <td>Execution Node</td>
+            <td>
+              Ingestion Engine<br/>
+              Provider Engine<br/>
+              Synchronization Engine<br/>
+              Flow Virtual Machine<br/>
+              Execution RPC API
+            </td>
+        </tr>
+        <tr>
+            <td>Verification Node</td>
+            <td>
+              Finder Engine<br/>
+              Matching Engine<br/>
+              Verifier Engine
+            </td>
+        </tr>
+        <tr>
+            <td>Access Node</td>
+            <td>Access RPC API</td>
+        </tr>
+        <tr>
+            <td>Flow Emulator</td>
+            <td></td>
+            <td>
+              Access RPC API<br/>
+              Flow Virtual Machine
+            </td>
+        </tr>
+        <tr>
+            <td>Cadence</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Flow JavaScript SDK</td>
+            <td></td>
+            <td>Flow Client Library (FCL)</td>
+        </tr>
+        <tr>
+            <td>Flow Go SDK</td>
+            <td></td>
+            <td>All public functions and variables</td>
+        </tr>
+        <tr>
+            <td>Flow CLI</td>
+            <td></td>
+            <td>All commands, flags and arguments</td>
+        </tr>
+    </tbody>
+</table>

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,137 @@
+# Flow Request for Comments (RFC)
+
+The purpose of a Flow RFC is to engage the Flow community in
+development by gathering feedback from contributors and experts while
+also communicating design changes broadly.
+
+## Who is involved?
+
+Any **community member** may help by providing feedback on whether the RFC will
+meet their needs.
+
+An **RFC author** is one or more community member who writes an RFC and is
+committed to championing it through the  process.
+
+An **RFC sponsor** is any maintainer who sponsors the RFC and will shepherd it
+through the RFC review process.
+
+A **review committee** is a group of maintainers who have the responsibility of
+recommending the adoption of the RFC.
+
+## What is a Flow RFC?
+
+An RFC is a document that describes a requirement and the proposed changes that
+will solve it. Specifically, the RFC will:
+
+* be formatted according to the RFC template
+* be submitted as a pull request to the
+  [onflow/flow/rfcs](https://github.com/onflow/flow/tree/master/rfcs) directory
+* be subject to discussion and a review meeting prior to acceptance
+
+## RFC process
+
+Before submitting an RFC, it is a good idea to discuss your aims with project
+contributors and maintainers and get early feedback. Use the [Flow community forum](https://forum.onflow.org/) or [Discord server](https://discord.gg/flow). After writing the RFC draft, get feedback from these experts before submitting it.
+
+1. Recruit a sponsor from the maintainers of the project which your RFC concerns.
+
+   Identify them in the RFC, before posting the PR in step 2.
+   If no sponsor is found you may still post the RFC, but if 
+   within a month of posting the PR there is still no sponsor,
+   it will be closed.
+
+2. Submit your RFC as a pull request to [onflow/flow](https://github.com/onflow/flow). 
+
+   Name your RFC file using the [template](./yyyymmdd-rfc-template.md) `YYYYMMDD-descriptive-name.md`, where
+   YYYYMMDD is the date of submission, and ‘descriptive-name’ relates to the
+   title of your RFC. For instance, if your RFC is titled “Event Streaming API”,
+   you might use the filename `20180531-event-streaming-api.md`. If you have images
+   or other auxiliary files, create a directory of the form `YYYYMMDD-descriptive-name`
+   in which to store those files.
+
+   Include the header table and the contents of the **Objective** section 
+   in the comment of your pull request, using Markdown. For an example,
+   please see [this example RFC](https://github.com/onflow/flow/pull/5). Include a mention of any of the GitHub handles of co-authors, reviewers, and sponsors.
+
+   At the top of the PR identify how long the comment period will be. This
+   should be a minimum of two weeks from posting the PR.
+
+3. Send a message to the #developers channel on [Discord](https://discord.gg/flow) with 
+   a brief description, and a link to the PR and a request for review.
+
+4. The sponsor may request a review committee meeting after sufficient discussion has 
+   taken place. This meeting will include the the RFC author, core contributors and interested community members. If discussion is lively, wait until it has settled before going to review. The goal of the review meeting is to resolve minor issues; consensus should be reached on major issues beforehand.
+
+5. The meeting may approve the RFC, reject it, or require changes before it
+   can be considered again. Approved RFCs will be merged into `onflow/flow/rfcs`, and
+   rejected RFCs will have their PRs closed.
+
+6. Implementations of a successful RFC should reference it in their
+   documentation, and work with the sponsor to successfully land the code.
+
+While implementation code is not necessary to start the RFC process, its
+existence in full or part may help the design discussion.
+
+If in any doubt about this process, feel free to ask on the
+developers mailing list or file an issue in [onflow/flow](https://github.com/onflow/flow/issues).
+
+## Community members
+
+As the purpose of RFCs is to ensure the community is well represented and served
+by new changes to Flow, it is the responsibility of community members to
+participate in reviewing RFCs where they have an interest in the outcome.
+
+Community members should:
+
+* provide feedback as soon as possible to allow adequate time for consideration
+* read RFCs thoroughly before providing feedback
+* be civil and constructive
+
+## Review committees
+
+The constitution of a review committee may change according to the particular
+governance style and leadership of each project. For the core Flow Protocol, the
+committee will exist of contributors to Flow who have expertise in the domain area concerned.
+
+Review committees must:
+
+* ensure that substantive items of public feedback have been accounted for
+* add their meeting notes as comments to the PR
+* provide reasons for their decisions
+
+If a review committee requires changes before acceptance, it is the
+responsibility of the sponsor to ensure these are made and seek subsequent
+approval from the committee members.
+
+## RFC sponsors
+
+A sponsor is a Flow maintainer responsible for ensuring the best possible
+outcome of the RFC process. In particular this includes:
+
+* advocating for the proposed design
+* guiding the RFC to adhere to existing design and style conventions
+* guiding the review committee to come to a productive consensus
+* if the RFC moves to implementation:
+  * ensuring proposed implementation adheres to the design
+  * liaison with appropriate parties to successfully land implementation
+
+## Keeping the bar high
+
+While we encourage and celebrate every contributor, the bar for RFC acceptance
+should be kept intentionally high. A design may be rejected or need significant
+revision at any one of these stages:
+
+* initial design conversations on the [Flow community forum](https://forum.onflow.org/) or [Discord server](https://discord.gg/flow)
+* failure to recruit a sponsor
+* critical objections during the feedback phase
+* failure to achieve consensus during the design review
+* concerns raised during implementation (e.g., inability to achieve backwards
+  compatibility, concerns about maintenance appearing once a partial implementation
+  is available)
+
+If this process is functioning well, RFCs are expected to fail in the earlier,
+rather than later, stages.
+
+## RFC Template
+
+Use the template [from GitHub](./yyyymmdd-rfc-template.md), being sure to follow the naming conventions described above.

--- a/rfcs/yyyymmdd-rfc-template.md
+++ b/rfcs/yyyymmdd-rfc-template.md
@@ -1,0 +1,78 @@
+# Title of RFC
+
+| Status        | (Proposed / Accepted / Implemented / Obsolete)       |
+:-------------- |:---------------------------------------------------- |
+| **RFC #**     | [NNN](https://github.com/onflow/flow/pull/NNN) (update when you have PR #)|
+| **Author(s)** | My Name (me@example.org), AN Other (you@example.org) |
+| **Sponsor**   | A N Expert (core-contributor@example.org)            |
+| **Updated**   | YYYY-MM-DD                                           |
+| **Obsoletes** | RFC it replaces, else remove this header             |
+
+## Objective
+
+What are we doing and why? What problem will this solve? What are the goals and
+non-goals? This is your executive summary; keep it short, elaborate below.
+
+## Motivation
+
+Why this is a valuable problem to solve? What background information is needed
+to show how this design addresses the problem?
+
+Which users are affected by the problem? Why is it a problem? What data supports
+this? What related work exists?
+
+## User Benefit
+
+How will users (or other contributors) benefit from this work? What would be the
+headline in the release notes or blog post?
+
+## Design Proposal
+
+This is the meat of the document, where you explain your proposal. If you have
+multiple alternatives, be sure to use sub-sections for better separation of the
+idea, and list pros/cons to each approach. If there are alternatives that you
+have eliminated, you should also list those here, and explain why you believe
+your chosen approach is superior.
+
+Make sure you’ve thought through and addressed the following sections. If a 
+section is not relevant to your specific proposal, please explain why, e.g. 
+your RFC addresses a convention or process, not an API.
+
+### Alternatives Considered
+* Make sure to discuss the relative merits of alternatives to your proposal.
+
+### Performance Implications
+* Do you expect any (speed / memory)? How will you confirm?
+* There should be microbenchmarks. Are there?
+* There should be end-to-end tests and benchmarks. If there are not (since this is still a design), how will you track that these will be created?
+
+### Dependencies
+* Dependencies: does this proposal add any new dependencies to Flow?
+* Dependent projects: are there other areas of Flow or things that use Flow (Access API, Wallets, SDKs, etc.) that this affects? How have you identified these dependencies and are you sure they are complete? If there are dependencies, how are you managing those changes?
+
+### Engineering Impact
+* Do you expect changes to binary size / build time / test times?
+* Who will maintain this code? Is this code in its own buildable unit? Can this code be tested in its own? Is visibility suitably restricted to only a small API surface for others to use?
+
+### Best Practices
+* Does this proposal change best practices for some aspect of using/developing Flow? How will these changes be communicated/enforced?
+
+### Tutorials and Examples
+* If design changes existing API or creates new ones, the design owner should create end-to-end examples (ideally, a tutorial) which reflects how new feature will be used. Some things to consider related to the tutorial:
+    - It should show the usage of the new feature in an end to end example (i.e. from the browser to the execution node). Many new features have unexpected effects in parts far away from the place of change that can be found by running through an end-to-end example.
+    - This should be written as if it is documentation of the new feature, i.e., consumable by a user, not a Flow contributor. 
+    - The code does not need to work (since the feature is not implemented yet) but the expectation is that the code does work before the feature can be merged. 
+
+### Compatibility
+* Does the design conform to the backwards & forwards compatibility [requirements](../docs/compatibility)?
+* How will this proposal interact with other parts of the Flow Ecosystem?
+    - How will it work with FCL?
+    - How will it work with the Emulator?
+    - How will it work with existing Flow SDKs?
+
+### User Impact
+* What are the user-facing changes? How will this feature be rolled out?
+
+## Questions and Discussion Topics
+
+Seed this with open questions you require feedback on from the RFC process.


### PR DESCRIPTION
This PR proposes an initial draft of the Flow RFC process. This is slightly meta, but I'd like make a formal _request for comment_ on this _request for comment_ process. 😄 

The goal of this process is twofold:
1. Encourage our core development team to begin moving architecture decisions into the open.
2. Provide a way for community contributors to formally engage in the Flow design process.

I adapted the RFC guidelines and template from the [tensorflow/community](https://github.com/tensorflow/community/tree/master/rfcs) repository, which is licensed under Apache 2.0. 

**Everything in this PR is subject to change. Please be liberal in your suggestions.**

We don't even need to use the term RFC! A few other possibilities (please feel free to add more):
- Flow Improvement Proposal (FIP)
- Flow Development Proposal (FDP)

I included a page about compatibility, which is also adapted from the TensorFlow community documentation.

