### PR TITLE
Add support for highlighting inline code

### DIFF
--- a/docs/plugins/gatsby-theme-flow/gatsby-config.js
+++ b/docs/plugins/gatsby-theme-flow/gatsby-config.js
@@ -64,6 +64,7 @@ module.exports = ({
           'solidity': 'source.solidity.security',
           'javascript': 'source.js',
           'shell': 'source.shell',
+          'sh': 'source.shell',
           'go': 'source.go',
           'js': 'source.js',
           'json': 'source.json',

--- a/docs/plugins/gatsby-theme-flow/src/components/code-block.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/code-block.js
@@ -80,6 +80,11 @@ CodeBlockHeader.propTypes = {
 
 export default function CodeBlock(props) {
   const codeRef = useRef();
+
+  if (props.className.includes('inline')) {
+    return <pre {...props} />
+  }
+
   return (
     <Container>
       <CodeBlockHeader codeRef={codeRef} />

--- a/docs/plugins/gatsby-theme-flow/src/components/code-block.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/code-block.js
@@ -81,7 +81,7 @@ CodeBlockHeader.propTypes = {
 export default function CodeBlock(props) {
   const codeRef = useRef();
 
-  if (props.className.includes('inline')) {
+  if (props.className && props.className.includes('inline')) {
     return <pre {...props} />
   }
 

--- a/docs/plugins/gatsby-theme-flow/src/styles.less
+++ b/docs/plugins/gatsby-theme-flow/src/styles.less
@@ -154,6 +154,11 @@ code {
   font-size: 0.9rem;
 }
 
+p > pre.inline {
+  padding: 0 0.4em;
+  line-height: 3em;
+}
+
 @keyframes animatebg {
   0% {
     background-position: 0 0;


### PR DESCRIPTION
This PR enables inline code which is prefixed with a language tag (identifier + `•`) to be highlighted:

```
`cadence•fun test() {}`
````

This is not limited to Cadence code, but very useful in the Cadence documentation.
