### PR TITLE
Add enumerations to sidebar of Cadence language documentation

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -299,6 +299,7 @@ const sections = [
         "docs/language/composite-types",
         "docs/language/access-control",
         "docs/language/interfaces",
+        "docs/language/enumerations",
         "docs/language/restricted-types",
         "docs/language/references",
         "docs/language/imports",


### PR DESCRIPTION
Support for enumerations was recently added to Cadence in https://github.com/onflow/cadence/pull/344.

Add the new page to the language reference.