### PR TITLE
Docs terminology cleaning

### DIFF
--- a/docs/content/token/staking/index.mdx
+++ b/docs/content/token/staking/index.mdx
@@ -50,7 +50,7 @@ If a staker does not meet the minimum requirement, their committed tokens are
 moved to their unlocked pool, which they can withdraw from at any time.
 
 At anytime, you can submit a `request_unstake.cdc` transaction
-which will move your tokens to the unbonding pool at the end of the current epoch.
+which will move your tokens to the unstaking pool at the end of the current epoch.
 They will sit in this pool for one (1) additional epoch,
 at which point you will be able to withdraw your tokens via `withdraw_unlocked_tokens.cdc` transaction.
 
@@ -109,7 +109,7 @@ the tokens you have committed will be marked as staked for the next epoch
 and held in the protocol state for the node that was delegated to.
 
 At anytime, a delegator can submit a `del_request_unstaking.cdc` transaction
-which will move their tokens to the unbonding pool at the end of the current epoch.
+which will move their tokens to the unstaking pool at the end of the current epoch.
 They will sit in this pool for one (1) additional epoch,
 at which point they will be able to withdraw their tokens via `del_withdraw_unlocked_tokens.cdc` transaction.
 
@@ -140,8 +140,8 @@ Each node operator has five token pools allocated to them:
 They are automatically moved to the staked pool when the next epoch starts.
 - Staked Tokens: Tokens that are staked by the node operator for the current epoch.
 They are only moved at the end of an epoch and if the staker 
-has submitted an unbonding request.
-- Unbonding Tokens: Tokens that have been unstaked, 
+has submitted an unstaking request.
+- Unstaking Tokens: Tokens that have been unstaked,
 but are not free to withdraw until the following epoch. 
 - Unlocked Tokens: Tokens that are freely available to withdraw or re-stake.
 Unstaked tokens go to this pool.
@@ -150,10 +150,10 @@ Unstaked tokens go to this pool.
 
 At the end of every epoch, tokens are moved between pools in this order:
 
-1. All Committed Tokens will get moved either to the Staked Tokens pool, or to the Unbonded Tokens pool (depending on if the staked request has met the minimum stake).
+1. All Committed Tokens will get moved either to the Staked Tokens pool, or to the Unstaked Tokens pool (depending on if the staked request has met the minimum stake).
 2. All Committed Tokens get moved to staked Tokens pool.
-3. All unbonding tokens get moved to the unlocked tokens pool.
-4. All requested unbonding tokens get moved from the staked pool to the unbonding pool.
+3. All unstaking tokens get moved to the unlocked tokens pool.
+4. All requested unstaking tokens get moved from the staked pool to the unstaking pool.
 
 ## Rewards
 
@@ -220,14 +220,14 @@ Severe slashing on Flow only takes place in the most nefarious of attacks.
 The protocol reserves slashing for maintaining the security of the protocol rather than its liveness.
 You can find more details on the conditions under which a node is slashed in a different part of the docs.
 
-While a node is in operation and during the unbonding period thereafter, 
+While a node is in operation and during the unstaking period thereafter,
 the staked tokens are held by the staking smart contract.
 Slashable protocol violations must be adjudicated by a supermajority 
 of more than 2/3 of the staked consensus nodes in order to take effect.
 If a node is found guilty of committing a slashable protocol violation, 
 the consensus nodes directly deduct a fine from the node's stake. 
 Of course, only the remaining stake is deposited back into node's balance
-at the end of the unbonding period.
+at the end of the unstaking period.
 
 ## FAQ
 **When will the User Accounts for Node Operators be created?**
@@ -329,7 +329,7 @@ transaction(amount: UFix64) {
 }
 ```
 
-### Request Staking Unbonding
+### Request Stake Unstaking
 
 ```cadence:title=request_unstake.cdc
 import FlowIDTableStaking from 0xIDENTITYTABLEADDRESS

--- a/docs/content/token/staking/index.mdx
+++ b/docs/content/token/staking/index.mdx
@@ -47,25 +47,25 @@ want, but they will be locked in to stake after that and will be subject to stak
 Once the next epoch starts, if you have committed at least the minimum,
 the tokens you have committed will be marked as staked and held in the protocol state.
 If a staker does not meet the minimum requirement, their committed tokens are 
-moved to their unlocked pool, which they can withdraw from at any time.
+moved to their unstaked pool, which they can withdraw from at any time.
 
 At anytime, you can submit a `request_unstake.cdc` transaction
 which will move your tokens to the unstaking pool at the end of the current epoch.
 They will sit in this pool for one (1) additional epoch,
-at which point you will be able to withdraw your tokens via `withdraw_unlocked_tokens.cdc` transaction.
+at which point you will be able to withdraw your tokens via `withdraw_unstaked_tokens.cdc` transaction.
 
 Staking rewards are paid at the end of every epoch. Every node's rewards
-are deposited to their unlocked tokens pool. They can be withdrawn
+are deposited to their unstaked tokens pool. They can be withdrawn
 at any time by submitting the `withdraw_reward_tokens.cdc` transaction.
 
 You can commit more tokens to stake for the next epoch at any time,
 and there are three different ways to do it.
 1. You can commit new tokens to stake by submitting the `stake_new_tokens.cdc` transaction,
 which withdraws tokens from your account's flow token vault and commits them.
-2. You can commit tokens that are in your unlocked token pool, which holds the tokens
-that you have unstaked. Submit the `stake_unlocked_tokens.cdc`
-transaction to move the tokens from the unlocked pool to the committed pool.
-3. You can commit tokens that are in your unlocked token pool, which holds the tokens
+2. You can commit tokens that are in your unstaked token pool, which holds the tokens
+that you have unstaked. Submit the `stake_unstaked_tokens.cdc`
+transaction to move the tokens from the unstaked pool to the committed pool.
+3. You can commit tokens that are in your unstaked token pool, which holds the tokens
 you have been awarded. Submit the `stake_rewarded_tokens.cdc`
 transaction to move the tokens from the rewards pool to the committed pool.
 
@@ -111,11 +111,11 @@ and held in the protocol state for the node that was delegated to.
 At anytime, a delegator can submit a `del_request_unstaking.cdc` transaction
 which will move their tokens to the unstaking pool at the end of the current epoch.
 They will sit in this pool for one (1) additional epoch,
-at which point they will be able to withdraw their tokens via `del_withdraw_unlocked_tokens.cdc` transaction.
+at which point they will be able to withdraw their tokens via `del_withdraw_unstaked_tokens.cdc` transaction.
 
 Every delegator's rewards are still deposited to their rewarded tokens pool.
 The node operator's delegation logic tracks how much each delegator has received.
-A delegator can withdraw their rewards from the unlocked tokens pool
+A delegator can withdraw their rewards from the unstaked tokens pool
 at any time by submitting the `del_withdraw_rewarded_tokens.cdc` transaction.
 
 Like regular node operators, delegators can also commit more tokens to stake for the next epoch
@@ -123,9 +123,9 @@ and there are two different ways to do it.
 1. They can commit new tokens to stake by submitting the `del_stake_new_tokens.cdc` transaction,
 which withdraws tokens from their account's flow token vault 
 and commits them to the saved node operator.
-2. They can commit tokens that are in their unlocked token pool, which holds 
-the tokens that they have unstaked. Submit the `del_stake_unlocked.cdc`
-transaction to move the tokens from the unlocked pool to the committed pool for the node.
+2. They can commit tokens that are in their unstaked token pool, which holds 
+the tokens that they have unstaked. Submit the `del_stake_unstaked.cdc`
+transaction to move the tokens from the unstaked pool to the committed pool for the node.
 3. They can commit tokens that are in their rewarded token pool, which holds the tokens
 they have been awarded. Submit the `del_stake_rewarded.cdc`
 transaction to move the tokens from the rewards pool to the committed pool for the node.
@@ -143,16 +143,16 @@ They are only moved at the end of an epoch and if the staker
 has submitted an unstaking request.
 - Unstaking Tokens: Tokens that have been unstaked,
 but are not free to withdraw until the following epoch. 
-- Unlocked Tokens: Tokens that are freely available to withdraw or re-stake.
+- Unstaked Tokens: Tokens that are freely available to withdraw or re-stake.
 Unstaked tokens go to this pool.
-- Rewarded Tokens: Tokens that are freely available to withdraw or re-stake. Rewards are paid and deposited to the Unlocked Pool after each epoch.
-- Rewards from the epoch are deposited into the Unlocked Pool.
+- Rewarded Tokens: Tokens that are freely available to withdraw or re-stake. Rewards are paid and deposited to the Unstaked Pool after each epoch.
+- Rewards from the epoch are deposited into the Unstaked Pool.
 
 At the end of every epoch, tokens are moved between pools in this order:
 
 1. All Committed Tokens will get moved either to the Staked Tokens pool, or to the Unstaked Tokens pool (depending on if the staked request has met the minimum stake).
 2. All Committed Tokens get moved to staked Tokens pool.
-3. All unstaking tokens get moved to the unlocked tokens pool.
+3. All unstaking tokens get moved to the unstaked tokens pool.
 4. All requested unstaking tokens get moved from the staked pool to the unstaking pool.
 
 ## Rewards

--- a/docs/content/token/staking/node-operators.mdx
+++ b/docs/content/token/staking/node-operators.mdx
@@ -41,6 +41,6 @@ and receive a proportional percentage of your node's rewards, as determined by y
 Stake can be [unstaked / withdrawn](custody-staking-and-delivery#unstaking-withdrawing-stake)
 after a week-long lock-up.
 
-Rewards are deposited into the same pool of unlocked tokens where unstaked tokens are stored.
+Rewards are deposited into the same pool of unstaked tokens where unstaked tokens are stored.
 You can [withdraw these tokens at anytime](custody-staking-and-delivery#withdrawing-rewards).
-You can also [re-stake them](custody-staking-and-delivery#staking-unlocked-stake), if desired.
+You can also [re-stake them](custody-staking-and-delivery#staking-unstaked-stake), if desired.

--- a/docs/content/token/staking/node-operators.mdx
+++ b/docs/content/token/staking/node-operators.mdx
@@ -41,6 +41,6 @@ and receive a proportional percentage of your node's rewards, as determined by y
 Stake can be [unstaked / withdrawn](custody-staking-and-delivery#unstaking-withdrawing-stake)
 after a week-long lock-up.
 
-Rewards are deposited into the same pool of unstaked tokens where unstaked tokens are stored.
+Rewards are deposited into their own pool of reward tokens.
 You can [withdraw these tokens at anytime](custody-staking-and-delivery#withdrawing-rewards).
 You can also [re-stake them](custody-staking-and-delivery#staking-unstaked-stake), if desired.

--- a/docs/content/token/staking/node-operators.mdx
+++ b/docs/content/token/staking/node-operators.mdx
@@ -36,11 +36,11 @@ If you operate a node and want to allow other token holders to delegate tokens t
 you can [enable delegation for your node](custody-staking-and-delivery#delegation), which allows any user to commit stake for your node 
 and receive a proportional percentage of your node's rewards, as determined by you.
 
-## Unbonding / Withdrawing Stake and Rewards
+## Unstaking / Withdrawing Stake and Rewards
 
-Stake can be [unbonded / withdrawn](custody-staking-and-delivery.mdx#unbonding-/-withdrawing-stake)
+Stake can be [unstaked / withdrawn](custody-staking-and-delivery#unstaking-withdrawing-stake)
 after a week-long lock-up.
 
-Rewards are deposited into the same pool of unlocked tokens where unbonded tokens are stored.
+Rewards are deposited into the same pool of unlocked tokens where unstaked tokens are stored.
 You can [withdraw these tokens at anytime](custody-staking-and-delivery#withdrawing-rewards).
 You can also [re-stake them](custody-staking-and-delivery#staking-unlocked-stake), if desired.

--- a/docs/content/token/staking/staking-as-a-service.mdx
+++ b/docs/content/token/staking/staking-as-a-service.mdx
@@ -63,7 +63,7 @@ can do a few different things.
 Token Holder:
 - Remove the token holder's stake via the `sh_request_unstaking.cdc` transaction
   (configuring this to require signatures from either or both parties is an available option).
-  This unstaking is still subject to the weeklong unbonding period before
+  This unstaking is still subject to the weeklong unstaking period before
   the requested tokens are available to be withdrawn.
 - Withdraw unstaked tokens via `sh_withdraw_unlocked_tokens.cdc` transaction,
   which will deposit them into the token holder's account regardless of who intiaited the transaction.

--- a/docs/content/token/staking/staking-as-a-service.mdx
+++ b/docs/content/token/staking/staking-as-a-service.mdx
@@ -65,7 +65,7 @@ Token Holder:
   (configuring this to require signatures from either or both parties is an available option).
   This unstaking is still subject to the weeklong unstaking period before
   the requested tokens are available to be withdrawn.
-- Withdraw unstaked tokens via `sh_withdraw_unlocked_tokens.cdc` transaction,
+- Withdraw unstaked tokens via `sh_withdraw_unstaked_tokens.cdc` transaction,
   which will deposit them into the token holder's account regardless of who intiaited the transaction.
 - Withdraw rewarded tokens via `sh_withdraw_rewarded_tokens.cdc` transaction,
   which will deposit them into the corresponding accounts regardless of who
@@ -73,7 +73,7 @@ Token Holder:
   (this will automatically distribute the rewards to both the staker and node operator,
   as defined by the cut of rewards the node receives at creation of the `StakingHelper` resource).
 - Commit additional tokens to stake via the `sh_stake_new_tokens.cdc` transaction.
-- Commit unstaked tokens to stake via the `sh_stake_unlocked_tokens.cdc` transaction.
+- Commit unstaked tokens to stake via the `sh_stake_unstaked_tokens.cdc` transaction.
 - Commit rewards tokens to stake via the `sh_stake_rewarded_tokens.cdc` transaction.
 
 If either party wants to end the relationship and not manage the node or stake

--- a/docs/content/token/staking2/delegators.mdx
+++ b/docs/content/token/staking2/delegators.mdx
@@ -111,4 +111,4 @@ transaction with the following arguments:
 | **amount** | UFix64  | The number of FLOW tokens to withdraw. |
 
 This transaction moves the rewarded tokens back into the `LockedTokens.Lockbox` owned by the **token holder**. 
-However, unlike unstaked tokens, rewards are **unlocked FLOW** and can be immediately withdrawn from the lockbox.
+However, unlike unstaked tokens, rewards are **unstaked FLOW** and can be immediately withdrawn from the lockbox.

--- a/docs/content/token/staking2/delegators.mdx
+++ b/docs/content/token/staking2/delegators.mdx
@@ -111,4 +111,4 @@ transaction with the following arguments:
 | **amount** | UFix64  | The number of FLOW tokens to withdraw. |
 
 This transaction moves the rewarded tokens back into the `LockedTokens.Lockbox` owned by the **token holder**. 
-However, unlike unstaked tokens, rewards are **unstaked FLOW** and can be immediately withdrawn from the lockbox.
+However, unlike unstaked tokens, rewards are **unlocked FLOW** and can be immediately withdrawn from the lockbox.

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -115,9 +115,9 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to add to the user's stake. |
 
-Since rewarded tokens are considered to be unlocked for the purposes of the vesting schedule,
+Since rewarded tokens are considered to be unstaked for the purposes of the vesting schedule,
 and staked tokens are considered locked, staking rewarded tokens marks the staked tokens as locked
-and marks an equal amount of tokens in the user's locked account as unlocked.
+and marks an equal amount of tokens in the user's locked account as unstaked.
 
 ## Unstake Tokens
 
@@ -157,5 +157,5 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw from the proxy. |
 
-Since rewards are considered to be unlocked. This marks an equal amount in your locked account as unlocked.
-You can immediately withdraw your unlocked reward tokens from your account after withdrawing rewards.
+Since rewards are considered to be unstaked. This marks an equal amount in your locked account as unstaked.
+You can immediately withdraw your unstaked reward tokens from your account after withdrawing rewards.

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -90,7 +90,7 @@ Transaction arguments:
 
 This transaction commits tokens to stake from the user's locked token account.
 
-## Stake Unbonded Tokens
+## Stake Unstaked Tokens
 
 To stake unstaked tokens (tokens that had been previously staked but were unstaked) via the proxy, 
 the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
@@ -101,7 +101,7 @@ Transaction arguments:
 
 | Argument   | Type   | Purpose |
 |------------|--------|---------|
-| **amount** | UFix64 | The quantity of unbonded FLOW tokens to add to the user's stake. |
+| **amount** | UFix64 | The quantity of unstaked FLOW tokens to add to the user's stake. |
 
 ## Stake Rewarded Tokens
 
@@ -143,7 +143,7 @@ Transaction arguments:
 
 | Argument   | Type   | Purpose |
 |------------|--------|---------|
-| **amount** | UFix64 | The quantity of unbonded FLOW tokens to withdraw from the proxy. |
+| **amount** | UFix64 | The quantity of unstaked FLOW tokens to withdraw from the proxy. |
 
 ## Withdraw Rewarded Tokens
 

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -115,9 +115,9 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to add to the user's stake. |
 
-Since rewarded tokens are considered to be unstaked for the purposes of the vesting schedule,
+Since rewarded tokens are considered to be unlocked for the purposes of the vesting schedule,
 and staked tokens are considered locked, staking rewarded tokens marks the staked tokens as locked
-and marks an equal amount of tokens in the user's locked account as unstaked.
+and marks an equal amount of tokens in the user's locked account as unlocked.
 
 ## Unstake Tokens
 
@@ -157,5 +157,5 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw from the proxy. |
 
-Since rewards are considered to be unstaked. This marks an equal amount in your locked account as unstaked.
-You can immediately withdraw your unstaked reward tokens from your account after withdrawing rewards.
+Since rewards are considered to be unlocked for the purposes of vesting. This marks an equal amount in your locked account as unlocked.
+You can immediately withdraw your unlocked reward tokens from your account after withdrawing rewards.

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -35,24 +35,24 @@ The **shared account** is used to store all locked FLOW owned by a **token holde
 |**`TA.01`**| Set Up Admin Account     | `lockedTokens/admin/create_admin_collection.cdc` |
 |**`TA.02`**| Created Shared Account   | `lockedTokens/admin/create_shared_account.cdc` |
 |**`TA.04`**| Deposit Locked Tokens    | `lockedTokens/admin/deposit_locked_tokens.cdc` |
-|**`TA.05`**| Unstake Tokens           | `lockedTokens/admin/unstake_tokens.cdc` |
+|**`TA.05`**| Unlock Tokens           | `lockedTokens/admin/unlock_tokens.cdc` |
 
 ## Token Holder (TH)
 
 The **token holder** is a user who holds possession of 
-locked and unstaked FLOW tokens.
+locked and unlocked FLOW tokens.
 
-The **token holder** can stake and delegate locked or unstaked FLOW
+The **token holder** can stake and delegate locked or unlocked FLOW
 through the `StakingProxy` contract.
 
-The **token holder** can withdraw unstaked FLOW from the shared account created 
+The **token holder** can withdraw unlocked FLOW from the shared account created 
 by the token admin.
 
 | ID | Name | Source |
 |----|------|--------|
-|**`TH.01`**| Withdraw Unstaked FLOW | `lockedTokens/user/withdraw_tokens.cdc` |
-|**`TH.02`**| Deposit Unstaked FLOW  | `lockedTokens/user/deposit_tokens.cdc` |
-|**`TH.03`**| Get Unstake Limit      | `lockedTokens/user/get_unstake_limit.cdc` |
+|**`TH.01`**| Withdraw Unlocked FLOW | `lockedTokens/user/withdraw_tokens.cdc` |
+|**`TH.02`**| Deposit Unlocked FLOW  | `lockedTokens/user/deposit_tokens.cdc` |
+|**`TH.03`**| Get Unlock Limit      | `lockedTokens/user/get_unlock_limit.cdc` |
 
 ### Staking (with `Lockbox.NodeStakerProxy`)
 
@@ -91,7 +91,7 @@ behalf of a **token holder**.
 ### Staking (with `StakingProxy.NodeStakerProxy`)
 
 The  **node operator** can perform the following
-staking actions using locked or unstaked FLOW owned by the **token holder**.
+staking actions using locked or unlocked FLOW owned by the **token holder**.
 
 _Note: The **node operator** can perform these actions on behalf of 
 the **token holder**, but only with explicit permission. 

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -35,24 +35,24 @@ The **shared account** is used to store all locked FLOW owned by a **token holde
 |**`TA.01`**| Set Up Admin Account     | `lockedTokens/admin/create_admin_collection.cdc` |
 |**`TA.02`**| Created Shared Account   | `lockedTokens/admin/create_shared_account.cdc` |
 |**`TA.04`**| Deposit Locked Tokens    | `lockedTokens/admin/deposit_locked_tokens.cdc` |
-|**`TA.05`**| Unlock Tokens            | `lockedTokens/admin/unlock_tokens.cdc` |
+|**`TA.05`**| Unstake Tokens           | `lockedTokens/admin/unstake_tokens.cdc` |
 
 ## Token Holder (TH)
 
 The **token holder** is a user who holds possession of 
-locked and unlocked FLOW tokens.
+locked and unstaked FLOW tokens.
 
-The **token holder** can stake and delegate locked or unlocked FLOW
+The **token holder** can stake and delegate locked or unstaked FLOW
 through the `StakingProxy` contract.
 
-The **token holder** can withdraw unlocked FLOW from the shared account created 
+The **token holder** can withdraw unstaked FLOW from the shared account created 
 by the token admin.
 
 | ID | Name | Source |
 |----|------|--------|
-|**`TH.01`**| Withdraw Unlocked FLOW | `lockedTokens/user/withdraw_tokens.cdc` |
-|**`TH.02`**| Deposit Unlocked FLOW  | `lockedTokens/user/deposit_tokens.cdc` |
-|**`TH.03`**| Get Unlock Limit       | `lockedTokens/user/get_unlock_limit.cdc` |
+|**`TH.01`**| Withdraw Unstaked FLOW | `lockedTokens/user/withdraw_tokens.cdc` |
+|**`TH.02`**| Deposit Unstaked FLOW  | `lockedTokens/user/deposit_tokens.cdc` |
+|**`TH.03`**| Get Unstake Limit      | `lockedTokens/user/get_unstake_limit.cdc` |
 
 ### Staking (with `Lockbox.NodeStakerProxy`)
 
@@ -91,7 +91,7 @@ behalf of a **token holder**.
 ### Staking (with `StakingProxy.NodeStakerProxy`)
 
 The  **node operator** can perform the following
-staking actions using locked or unlocked FLOW owned by the **token holder**.
+staking actions using locked or unstaked FLOW owned by the **token holder**.
 
 _Note: The **node operator** can perform these actions on behalf of 
 the **token holder**, but only with explicit permission. 

--- a/docs/content/token/wallets.mdx
+++ b/docs/content/token/wallets.mdx
@@ -76,13 +76,13 @@ meaning they can't be sold, transferred or traded until sufficient time has pass
 
 Although locked tokens can't be liquidated, they can still be used for staking.
 Any staking rewards acrued from locked tokens are deposited into the rewardee's account
-as _unstaked tokens_.
+as _unlocked tokens_.
 
 ### FLOW.ICO vs FLOW
 
 It is the responsibility of the custodian to ensure that FLOW received from an ICO event (FLOW.ICO)
 is not liquidated before the legal lockup period has passed. In order to ensure that this does
-not happen, it is important to store FLOW.ICO tokens separately from unstaked FLOW tokens.
+not happen, it is important to store FLOW.ICO tokens separately from unlocked FLOW tokens.
 
 To achieve this separation, a custodian should provision a new token vault that follows this standard:
 

--- a/docs/content/token/wallets.mdx
+++ b/docs/content/token/wallets.mdx
@@ -76,13 +76,13 @@ meaning they can't be sold, transferred or traded until sufficient time has pass
 
 Although locked tokens can't be liquidated, they can still be used for staking.
 Any staking rewards acrued from locked tokens are deposited into the rewardee's account
-as _unlocked tokens_.
+as _unstaked tokens_.
 
 ### FLOW.ICO vs FLOW
 
 It is the responsibility of the custodian to ensure that FLOW received from an ICO event (FLOW.ICO)
 is not liquidated before the legal lockup period has passed. In order to ensure that this does
-not happen, it is important to store FLOW.ICO tokens separately from unlocked FLOW tokens.
+not happen, it is important to store FLOW.ICO tokens separately from unstaked FLOW tokens.
 
 To achieve this separation, a custodian should provision a new token vault that follows this standard:
 

--- a/docs/content/token/wallets.mdx
+++ b/docs/content/token/wallets.mdx
@@ -10,7 +10,7 @@ TODO:
 - Insert protocol for emitting event when tokens deposited into account
 - Peter to insert generalised websequence digram from this doc https://docs.google.com/document/d/1b1fVgHBlGYMu0WvIz5fwDMc153UGzXz0Pp2lr1atRrE/edit#heading=h.vyfahjj5ho25
 - Insert sequence diagram https://www.notion.so/dapperlabs/Token-Staking-Process-6877e85a057e4eab8beae7f5187f3ffb#6cdcd35f8084439d93da479f1dc0831d
-- Insert Unbonding transaction example
+- Insert Unstaking transaction example
 https://github.com/onflow/flow-internal/issues/1131
 
 -->


### PR DESCRIPTION
Replace mentions of bonding or locking with staking.

Transaction names in flow-core-contracts are clean.