### PR TITLE
Adds account creation docs

### DIFF
--- a/docs/content/token/staking/index.mdx
+++ b/docs/content/token/staking/index.mdx
@@ -214,31 +214,6 @@ Over time, the number of nodes will increase to promote participation
 but we don't anticipate increasing the number of participating nodes by more than double 
 in the first year of the network's operation.
 
-### Sample Rewards Calculation
-
-Example: You are delegating 5,000 FLOW to a consensus node. If we asume there are 29 consensus nodes
-active, each with the minimum amount staked. The calculation would look like this:
-- Tr = 5,000,000 FLOW
-- Tn = 0.518
-- Sn = 5,000 FLOW
-- St = (29 nodes) * (500,000 FLOW) = 
-```
-(Reward for Epoch) = ((5,000,000 FLOW) * (0.518)) * ((5,000 FLOW) / (14,500,000 FLOW))
-                   = (2,590,000 FLOW) * 0.0003448275862
-                   = ~893.1 FLOW
-```
-
-You would receive around 893.1 FLOW. Be aware that this is just an estimate based on
-the expected minimum amount of consensus nodes and stake. So this will definitely change.
-
-Accounts for receiving Rewards are conventional user accounts. 
-They can be created in exactly the same account-creation process. 
-Whoever is putting up the tokens to stake the node will have the right 
-to select which User-Account Address will receive rewards associated with that network identity. 
-In regular time intervals, the accumulated rewards a node earns are deposited into the 
-rewards pool of tokens for that node. The recipient for the rewards has to withdraw the 
-rewards they have received in order to store them in their own account.
-
 ## Slashing
 So, who gets slashed? 
 Severe slashing on Flow only takes place in the most nefarious of attacks. 

--- a/docs/content/token/staking2/delegators.mdx
+++ b/docs/content/token/staking2/delegators.mdx
@@ -5,48 +5,110 @@ sidebar_title: For Delegators
 
 # Introduction
 
-TODO
+This guide demonstrates how a **token holder** can delegate locked FLOW tokens to 
+another node using the `LockedTokens` contract.
 
 # Setup
 
+After the [account setup](#) process is complete, 
+the **token holder** will have access to a `LockedTokens.TokenHolder` resource in their storage.
+This resource can be used as a proxy to indirectly delegate locked FLOW tokens.
+
 ## Register as a Delegator
 
-TODO
-- Uses `registerLockedDelegator`
+To register as a delegator, the **token holder** can use the **Register Delegator** ([TH.12](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **id**     | `String`  | The ID of the node to delegate to. |
+| **amount** | `UFix64`  | The number of FLOW tokens to delegate. |
+
+This transaction attaches a `NodeDelegatorProxy` capability to the `TokenHolder` resource. 
+This capability can later be used to perform delegation actions.
 
 # Delegation Actions
 
 ## Delegate New Tokens
 
-TODO
-- Uses `delegateNewLockedTokens`
+The **token holder** can delegate additional tokens after registering as a delegator. 
 
-## Delegate Unbonded Tokens
+_Note: This transaction delegates additional tokens to the same node that was registered in the setup phase.
+It is currently not possible to delegate to multiple nodes from the same account._
 
-TODO
-- Uses `delegateLockedUnbondedTokens`
+To delegate new tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Delegate New Locked FLOW** ([TH.13](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy)) 
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | `UFix64` | The number of FLOW tokens to delegate. |
+
+## Delegate Unstaked Tokens
+
+After delegated tokens become unstaked, the **token holder** can choose to re-delegate the unstaked tokens to the same node.
+
+To delegate unstaked tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Re-delegate Unstaked FLOW** ([TH.14](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | UFix64  | The number of FLOW tokens to delegate. |
 
 ## Delegate Rewarded Tokens
 
-TODO
-- Uses `delegateLockedRewardedTokens`
+After earning rewards from delegation, the **token holder** can choose to re-delegate the rewarded tokens to the same node.
+
+To delegate rewarded tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Re-delegate Rewarded FLOW** ([TH.15](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | UFix64  | The number of FLOW tokens to delegate. |
 
 ## Unstake Delegated Tokens
 
-TODO
-- Uses `requestUnstakingLockedDelegatedTokens`
+The **token holder** can submit a request to unstake their delegated tokens at any time.
 
-## Unstake All Delegated Tokens
+To unstake delegated tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Unstake Delegated FOW** ([TH.16](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
 
-TODO
-- Uses `unstakeAllLockedDelegatedTokens`
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | UFix64  | The number of FLOW tokens to unstake. |
 
-## Withdraw Unbonded Tokens
+_Note: unstaked delegated tokens will be held by the central staking contract for a period of time before they are 
+released to the token holder. Once the tokens are released (unstaked), 
+they can be claimed via the [Withdraw Unstaked Tokens](#withdraw-unstaked-tokens) action below._
 
-TODO
-- Uses `withdrawLockedUnbondedDelegatedTokens`
+## Withdraw Unstaked Tokens
+
+After delegated tokens become unstaked, the **token holder** can withdraw them from the central staking contract.
+
+To withdraw unstaked tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Withdraw Unstaked FLOW ** ([TH.17](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | UFix64  | The number of FLOW tokens to withdraw. |
+
+This transaction moves the unstaked tokens back into the `LockedTokens.Lockbox` owned by the **token holder**.
 
 ## Withdraw Rewarded Tokens
 
-TODO
-- Uses `withdrawLockedRewardedDelegatedTokens`
+After earning rewards from delegation, the **token holder** can withdraw them from the central staking contract.
+
+To withdraw rewarded tokens via the `NodeDelegatorProxy`, 
+the **token holder** can use the **Withdraw Rewarded FLOW ** ([TH.18](/token/staking2/transactions/#delegating-with-lockboxnodedelegatorproxy))
+transaction with the following arguments:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| **amount** | UFix64  | The number of FLOW tokens to withdraw. |
+
+This transaction moves the rewarded tokens back into the `LockedTokens.Lockbox` owned by the **token holder**. 
+However, unlike unstaked tokens, rewards are **unlocked FLOW** and can be immediately withdrawn from the lockbox.

--- a/docs/content/token/staking2/delegators.mdx
+++ b/docs/content/token/staking2/delegators.mdx
@@ -1,0 +1,52 @@
+---
+title: How to Delegate FLOW
+sidebar_title: For Delegators
+---
+
+# Introduction
+
+TODO
+
+# Setup
+
+## Register as a Delegator
+
+TODO
+- Uses `registerLockedDelegator`
+
+# Delegation Actions
+
+## Delegate New Tokens
+
+TODO
+- Uses `delegateNewLockedTokens`
+
+## Delegate Unbonded Tokens
+
+TODO
+- Uses `delegateLockedUnbondedTokens`
+
+## Delegate Rewarded Tokens
+
+TODO
+- Uses `delegateLockedRewardedTokens`
+
+## Unstake Delegated Tokens
+
+TODO
+- Uses `requestUnstakingLockedDelegatedTokens`
+
+## Unstake All Delegated Tokens
+
+TODO
+- Uses `unstakeAllLockedDelegatedTokens`
+
+## Withdraw Unbonded Tokens
+
+TODO
+- Uses `withdrawLockedUnbondedDelegatedTokens`
+
+## Withdraw Rewarded Tokens
+
+TODO
+- Uses `withdrawLockedRewardedDelegatedTokens`

--- a/docs/content/token/staking2/index.mdx
+++ b/docs/content/token/staking2/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Staking
+---
+
+## Introduction
+
+Flow users can stake their tokens and run nodes in a variety of ways. 
+Please select the option that best matches your use case.
+
+1. [For Stakers](): I have **FLOW tokens** and I want to run a node with help from a **node operator**.
+1. [For Delegators](): I have **FLOW tokens** and I want to **delegate my tokens** to another node.
+1. [For Power Users](): I have **FLOW tokens** and I want to run **my own staked node**.
+1. [For Node Operators](): I am a **node operator** and I want to help others run nodes.

--- a/docs/content/token/staking2/index.mdx
+++ b/docs/content/token/staking2/index.mdx
@@ -7,7 +7,7 @@ title: Staking
 Flow users can stake their tokens and run nodes in a variety of ways. 
 Please select the option that best matches your use case.
 
-1. [For Stakers](): I have **FLOW tokens** and I want to run a node with help from a **node operator**.
-1. [For Delegators](): I have **FLOW tokens** and I want to **delegate my tokens** to another node.
-1. [For Power Users](): I have **FLOW tokens** and I want to run **my own staked node**.
-1. [For Node Operators](): I am a **node operator** and I want to help others run nodes.
+1. [For Stakers](/token/staking2/stakers): I have **FLOW tokens** and I want to run a node with help from a **node operator**.
+1. [For Delegators](/token/staking2/delegators): I have **FLOW tokens** and I want to **delegate my tokens** to another node.
+1. [For Power Users](/token/staking2/power-users): I have **FLOW tokens** and I want to run **my own staked node**.
+1. [For Node Operators](/token/staking2/node-operators): I am a **node operator** and I want to help others run nodes.

--- a/docs/content/token/staking2/node-operators.mdx
+++ b/docs/content/token/staking2/node-operators.mdx
@@ -2,3 +2,81 @@
 title: How to be a Flow Node Operator
 sidebar_title: For Node Operators
 ---
+
+# Introduction
+
+This guide covers the technical integration required for a **node operator (NO)** to operate
+a staked Flow node using locked FLOW provided by a **token holder (TH)**.
+
+Both parties have separate roles in this relationship:
+
+- **Node Operator:** Manages the node infrastructure but _does not hold_ any FLOW tokens.
+- **Token Holder:** Provides restricted, indirect access to their FLOW tokens for the sole purpose of staking.
+
+This guide assumes that the **node operator** has already established a 
+trusted relationship with a **token holder**.
+
+# Setup
+
+These are the steps taken by a **node operator** to set up the integration with a **token holder**.
+
+_Note: The corresponding **token holder** steps are outlined in a 
+[separate guide for token holders](/token/staking2/stakers)._
+
+## 1. Create a node operator account
+
+This step can be skipped if the **node operator** already has an account.
+
+TODO:
+- Uses `createOperatorAccount` transaction (`NO.01`)
+
+## 2. Create a new `NodeInfo` entry
+
+TODO:
+- Uses `addNodeInfo` transaction (`NO.02`)
+
+## 3. Confirm staking access with token holder
+
+After the `NodeInfo` object has been created and published, 
+the **token holder** uses it to initiate a staking request. 
+After this, the **token holder** passes a `StakingProxy.NodeStakerProxy`
+capability to the **node operator** that allows them to perform staking operations.
+
+The **node operator** should confirm that they have access to this capability.
+
+# Staking Actions
+
+## Stake New Tokens
+
+TODO
+- Uses `stakeNewLockedTokens`
+
+## Stake Unbonded Tokens
+
+TODO
+- Uses `stakeLockedUnbondedTokens`
+
+## Unstake Tokens
+
+TODO
+- Uses `unstakeLockedTokens`
+
+## Withdraw Unbonded Tokens
+
+TODO
+- Uses `withdrawLockedUnbondedTokens`
+
+## Withdraw Rewarded Tokens
+
+TODO
+- Uses `withdrawLockedRewardedTokens`
+
+# Teardown
+
+## Remove `NodeInfo` entry
+
+The **node operator** can destroy the `NodeInfo` entry after 
+the staking relationship has concluded.
+
+TODO
+- Uses `removeNodeInfo` transaction (`NO.03`)

--- a/docs/content/token/staking2/node-operators.mdx
+++ b/docs/content/token/staking2/node-operators.mdx
@@ -27,13 +27,29 @@ _Note: The corresponding **token holder** steps are outlined in a
 
 This step can be skipped if the **node operator** already has an account.
 
-TODO:
-- Uses `createOperatorAccount` transaction (`NO.01`)
+To create a node operator account, the node operator must use transaction [../transactions/node-operator-no#](NO.01):
+
+`stakingProxy/sh_setup_node_account.cdc`
+
+Transaction arguments:
+
+none.
 
 ## 2. Create a new `NodeInfo` entry
 
-TODO:
-- Uses `addNodeInfo` transaction (`NO.02`)
+To create a NodeInfo entry, the node operator must use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.02):
+
+`stakingProxy/sh_add_node_info.cdc`
+
+Transaction arguments:
+
+| Argument              | Type   | Purpose |
+|-----------------------|--------|---------|
+| **id**                | String | The unique identifier for the node. |
+| **role**              | UInt8  | The role number for the node, see FlowIDTableStaking.cdc . |
+| **networkingAddress** | String | The node's networking address. |
+| **networkingKey**     | String | The node's networking key. |
+| **stakingKey**        | String | The node's staking key. |
 
 ## 3. Confirm staking access with token holder
 
@@ -48,28 +64,67 @@ The **node operator** should confirm that they have access to this capability.
 
 ## Stake New Tokens
 
-TODO
-- Uses `stakeNewLockedTokens`
+To stake new tokens, the node operator must use use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.05):
 
-## Stake Unbonded Tokens
+`stakingProxy/sh_stake_new_tokens.cdc`
 
-TODO
-- Uses `stakeLockedUnbondedTokens`
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |
+| **amount** | UFix64 | The quantity of new FLOW tokens to add to the stake. |
+
+## Re-Stake Unstaked Tokens
+
+To re-stake previously unstaked tokens, the node operator must use use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.06):
+
+`stakingProxy/sh_stake_unstaked_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |
+| **amount** | UFix64 | The quantity of previously unstaked FLOW tokens to add to the stake. |
 
 ## Unstake Tokens
 
-TODO
-- Uses `unstakeLockedTokens`
+To unstake **all previously staked** tokens, the node operator must use use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.07):
 
-## Withdraw Unbonded Tokens
+`stakingProxy/sh_unstake_all.cdc`
 
-TODO
-- Uses `withdrawLockedUnbondedTokens`
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |
+
+## Withdraw Unstaked Tokens
+
+To withdraw previously unstaked tokens, the node operator must use use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.08):
+
+`stakingProxy/sh_withdraw_unstaked.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |
+| **amount** | UFix64 | The quantity of previously staked FLOW tokens to withdraw. |
 
 ## Withdraw Rewarded Tokens
 
-TODO
-- Uses `withdrawLockedRewardedTokens`
+To withdraw rewarded tokens, the node operator must use use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.09):
+
+`stakingProxy/sh_withdraw_rewards.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |
+| **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw. |
 
 # Teardown
 
@@ -78,5 +133,12 @@ TODO
 The **node operator** can destroy the `NodeInfo` entry after 
 the staking relationship has concluded.
 
-TODO
-- Uses `removeNodeInfo` transaction (`NO.03`)
+To do this they must use transaction [../transactions/#staking-with-stakingproxynodestakerproxy](NO.03):
+
+`stakingProxy/sh_remove_node_info.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **nodeID** | String | The unique identifier for the node. |

--- a/docs/content/token/staking2/node-operators.mdx
+++ b/docs/content/token/staking2/node-operators.mdx
@@ -1,0 +1,4 @@
+---
+title: How to be a Flow Node Operator
+sidebar_title: For Node Operators
+---

--- a/docs/content/token/staking2/power-users.mdx
+++ b/docs/content/token/staking2/power-users.mdx
@@ -1,0 +1,5 @@
+---
+title: How to Run a Staked Flow Node
+sidebar_title: For Power Users
+---
+

--- a/docs/content/token/staking2/setup.mdx
+++ b/docs/content/token/staking2/setup.mdx
@@ -3,7 +3,104 @@ title: Configure an Account to Receive Locked FLOW
 sidebar_title: Account Setup
 ---
 
-TODO
-- custody_create_only_shared_account.cdc
-- custody_create_shared_accounts.cdc
-- custody_setup_account_creator.cdc
+<Callout type="warning">
+
+  This guide is for custody providers or wallet providers to create user accounts 
+  that can hold locked tokens from the Flow token sale.
+  If you already have an account and wish to stake tokens, see other sections of the staking docs.
+
+</Callout>
+
+# Introduction
+
+This guide covers the technical integration required for custody providers to create
+accounts that store locked tokens for users.
+
+Every user who holds locked tokens gets two accounts.
+
+- **Account One - Shared Account:** This account is shared between the Flow token admin and the user.
+The user's key will have weight 900 and the token admin's key will have weight 100.
+Therefore, any transactions that directly access this account need to be signed by both parties.
+The locked tokens are stored in this account and the token admin has the authority to unlock
+tokens as outlined by the vesting schedule. This account also manages access to the staking
+and delegating functionality that a user signs up for.
+- **Account Two - Unlocked Account:** This account is completely controlled by the user.
+It includes an object that manages access to the functionality contained in the shared account.
+The user submits token withdrawal and staking transactions with this account.
+
+# Setup
+
+To enable your custody account to create accounts with locked tokens, you must
+run the transaction
+
+`lockedTokens/admin/custody_setup_account_creator.cdc`
+
+Transaction arguments:
+
+None.
+
+This transaction creates an `AccountCreator` object and stores it in the custody provider's account.
+It also publishes a capability that allows the token admin to give the custody provider 
+the authority to register locked token accounts.
+
+# Account Creation
+
+When a custody provider uses these transactions, they must also ensure that 
+the token admin knows which account addresses map to which users. This is so 
+the token admin knows how much to pay to each locked account
+and how many tokens to unlock via the vesting schedule.
+
+## 1. Creating Both Accounts for the user
+
+If your user does not have a regular account created for them yet, you must 
+create both accounts in a single transaction.
+
+`lockedTokens/admin/custody_create_shared_accounts.cdc`
+
+Transaction arguments:
+
+| Argument                  | Type    | Purpose |
+|---------------------------|---------|---------|
+| **partialAdminPublicKey** | [UInt8] | The public key of the token admin. Must be Weight: 100 |
+| **partialUserPublicKey**  | [UInt8] | The public key of the user. Must be Weight: 900 |
+| **fullUserPublicKey**     | [UInt8] | The public key of the user. Must be Weight: 1000 |
+
+
+## 2. Creating the Shared account for a user who already has a personal account
+
+If your user already has a personal account allocated to them, you can run a transaction
+that creates the shared account and gives their existing account the capability
+to interact with their locked tokens. 
+
+<Callout type="warning">
+
+  This transaction **MUST** also be signed and authorized by the existing user account.
+  It needs this because it needs to have access to the user's private storage and Authorized access.
+
+</Callout>
+
+`lockedTokens/admin/custody_create_only_shared_account.cdc`
+
+Transaction arguments:
+
+| Argument                  | Type    | Purpose |
+|---------------------------|---------|---------|
+| **partialAdminPublicKey** | [UInt8] | The public key of the token admin. Must be Weight: 100 |
+| **partialUserPublicKey**  | [UInt8] | The public key of the user. Must be Weight: 900 |
+
+
+Both transactions generally perform the same actions:
+
+1. Create the shared account and add the partial public keys to the account.
+2. Create the Locked Token Manager object in the shared account.
+3. Create the Token Holder object and store it in the user account. This object
+is what the user interacts with to withdraw unlocked tokens and perform staking actions.
+4. Register the new accounts with the token admin account so that 
+it can receive locked tokens from the vesting schedule.
+5. Override the default Flow Token receiver to mark received tokens as unlocked.
+6. Create a different Flow Token receiver that the token admin account uses to deposit locked tokens.
+
+
+
+
+

--- a/docs/content/token/staking2/setup.mdx
+++ b/docs/content/token/staking2/setup.mdx
@@ -43,6 +43,22 @@ This transaction creates an `AccountCreator` object and stores it in the custody
 It also publishes a capability that allows the token admin to give the custody provider 
 the authority to register locked token accounts.
 
+## Receive Account creator Capability
+
+After you have set up your account, the token admin needs to submit one more transaction
+to enable your account to register new user accounts to receive locked tokens.
+
+This transaction needs to be signed and authorized by the token admin account.
+
+`lockedTokens/admin/admin_deposit_account_creator.cdc`
+
+| Argument                    | Type    | Purpose |
+|-----------------------------|---------|---------|
+| **custodyProviderAddress**  | Address | The address of the custody provider's account. |
+
+This transaction gives the account registration capability to the custody provider's account
+that was set up in the previous transaction.
+
 # Account Creation
 
 When a custody provider uses these transactions, they must also ensure that 

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -4,8 +4,10 @@ sidebar_title: For Stakers
 ---
 
 <Callout type="warning">
-  This guide is for developers who wish to stake FLOW with the help of a node operator. 
+
+  This guide is for developers who wish to stake FLOW with the help of a **node operator**. 
   If you wish to operate your own node, please read the [power user guide](/token/staking2/power-users).
+
 </Callout>
 
 # Introduction

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -31,13 +31,16 @@ _Note: The corresponding **node operator** steps are outlined in a
 [separate guide for node operators](/token/staking2/node-operators)._
 
 ## 1. Fetch node operator information
-After a node operator has agreed to run a node for you, they will create a NodeInfo object holding the IP address and public keys for your new node. This NodeInfo object will be stored in an account owned by the node operator.
+After a node operator has agreed to run a node for you, they will create a NodeInfo object holding the IP address and public keys for your new node. 
+This NodeInfo object will be stored in an account owned by the node operator. This object acts as a staking proxy 
+for the node operator to access some staking options without actually having access to your tokens.
 
-The node operator should provide you with their account address and the nodeID for your new node. These parameters can be passed into the get_node_info script (TH.04) to confirm the node information.
+The node operator should provide you with their account address and the nodeID for your new node. 
+These parameters can be passed into the get_node_info script (TH.04) to confirm the node information.
 
 If the node information is correct, continue to step 2.
 
-To fetch the node operator information for an address's staking proxy, the token holder must use use script [../transactions/#staking-with-lockboxnodestakerproxy](TH.04):
+To fetch the node operator information for a node operator's staking proxy, the token holder must use use script [../transactions/#staking-with-lockboxnodestakerproxy](TH.04):
 
 `stakingProxy/sh_get_node_info.cdc`
 
@@ -50,7 +53,7 @@ Script arguments:
 
 Script returns:
 
-The `StakingProxy.NodeInfo` struct containing the details for the node. If no NodeInfo is available, the script will fail.
+The `StakingProxy.NodeInfo` struct contains the details for the node. If no NodeInfo is available, the script will fail.
 
 ## 2. Register node & grant staking access to the node operator
 
@@ -68,6 +71,11 @@ Transaction arguments:
 
 # Staking Actions
 
+Once the token holder has registered their node with the node operator's info, their tokens and info
+are committed to the central staking contract for the next epoch. They now have access to 
+various staking operations that they can perform at any time, assuming they have
+the correct number of tokens to perform the action.
+
 ## Stake New Tokens
 
 To stake new tokens via the proxy, the token holder must use use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.06):
@@ -80,12 +88,14 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of new FLOW tokens to add to the user's stake. |
 
+This transaction commits tokens to stake from the user's locked token account.
 
 ## Stake Unbonded Tokens
 
-To stake unbonded tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
+To stake unstaked tokens (tokens that had been previously staked but were unstaked) via the proxy, 
+the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
 
-`lockedTokens/staker/stake_unlocked_tokens.cdc`
+`lockedTokens/staker/stake_unstaked_tokens.cdc`
 
 Transaction arguments:
 
@@ -105,9 +115,13 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to add to the user's stake. |
 
+Since rewarded tokens are considered to be unlocked for the purposes of the vesting schedule,
+and staked tokens are considered locked, staking rewarded tokens marks the staked tokens as locked
+and marks an equal amount of tokens in the user's locked account as unlocked.
+
 ## Unstake Tokens
 
-To unstake their tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.09):
+To unstake all of their tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.09):
 
 `lockedTokens/staker/unstake_all.cdc`
 
@@ -117,11 +131,13 @@ None.
 
 **Note that this will unstake all of the user's staked tokens.**
 
-## Withdraw Unbonded Tokens
+When a user unstakes their tokens, they must wait until the end of the following epoch to be able to withdraw them.
 
-To withdraw unbonded tokens (tokens that were previously staked and then unstaked) via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.10):
+## Withdraw Unstaked Tokens
 
-`lockedTokens/staker/withdraw_unlocked_tokens.cdc`
+To withdraw unstaked tokens (tokens that were previously staked and then unstaked) via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.10):
+
+`lockedTokens/staker/withdraw_unstaked_tokens.cdc`
 
 Transaction arguments:
 
@@ -140,3 +156,6 @@ Transaction arguments:
 | Argument   | Type   | Purpose |
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw from the proxy. |
+
+Since rewards are considered to be unlocked. This marks an equal amount in your locked account as unlocked.
+You can immediately withdraw your unlocked reward tokens from your account after withdrawing rewards.

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -30,52 +30,47 @@ These are the steps required to set up the integration between a **token holder*
 _Note: The corresponding **node operator** steps are outlined in a 
 [separate guide for node operators](/token/staking2/node-operators)._
 
-## 1. Fetch Node Operator information
+## 1. Fetch node operator information
 
 TODO
 - Provide `operatorAddress, nodeID`
-- Uses `getOperatorNodeInfo` script
+- Uses `TH.04` script
 
-## 2. Submit a staking request
+## 2. Register node & grant staking access to the node operator
 
 TODO
 - Provide `amount` to be staked
-- Provide `operatorAddress, nodeID` to stake
-- Uses `registerNode` transaction
-
-## 3. Grant staking access to the Node Operator
-
-TODO
-- Uses `addStakingProxy` transaction
+- Provide `operatorAddress, nodeID` to stake to
+- Uses `TH.05` transaction
 
 # Staking Actions
 
 ## Stake New Tokens
 
 TODO
-- Uses `stakeNewLockedTokens`
+- Uses `TH.06` transaction
 
 ## Stake Unbonded Tokens
 
 TODO
-- Uses `stakeLockedUnbondedTokens`
+- Uses `TH.07` transaction
 
 ## Stake Rewarded Tokens
 
 TODO
-- Uses `stakeLockedRewardedTokens`
+- Uses `TH.08` transaction
 
 ## Unstake Tokens
 
 TODO
-- Uses `unstakeLockedTokens`
+- Uses `TH.09` transaction
 
 ## Withdraw Unbonded Tokens
 
 TODO
-- Uses `withdrawLockedUnbondedTokens`
+- Uses `TH.10` transaction
 
 ## Withdraw Rewarded Tokens
 
 TODO
-- Uses `withdrawLockedRewardedTokens`
+- Uses `TH.11` transaction

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -1,0 +1,75 @@
+---
+title: How to Stake FLOW
+sidebar_title: For Stakers
+---
+
+<Callout type="warning">
+  This guide is for developers who wish to stake FLOW with the help of a node operator. 
+  If you wish to operate your own node, please read the [power user guide](/token/staking2/power-users).
+</Callout>
+
+# Introduction
+
+This guide covers the technical integration required for a **token holder (TH)** and **node operator (NO)** 
+to jointly fund and operate a staked Flow node.
+
+Both parties have separate roles in this relationship:
+
+- **Node Operator:** Manages the node infrastructure but _does not hold_ any FLOW tokens.
+- **Token Holder:** Provides restricted, indirect access to their FLOW tokens for the sole purpose of staking.
+
+This guide assumes that the **token holder** has already estabilished a relationship with a trusted **node operator**.
+
+# Setup
+
+These are the steps required to set up the integration between a **token holder** and a **node operator**.
+
+## 1. Fetch Node Operator information
+
+TODO
+- Provide `operatorAddress, nodeID`
+- Uses `getOperatorNodeInfo` script
+
+## 2. Submit a staking request
+
+TODO
+- Provide `amount` to be staked
+- Provide `operatorAddress, nodeID` to stake
+- Uses `registerNode` transaction
+
+## 3. Grant staking access to the Node Operator
+
+TODO
+- Uses `addStakingProxy` transaction
+
+# Staking Actions
+
+## Stake New Tokens
+
+TODO
+- Uses `stakeNewLockedTokens`
+
+## Stake Unbonded Tokens
+
+TODO
+- Uses `stakeLockedUnbondedTokens`
+
+## Stake Rewarded Tokens
+
+TODO
+- Uses `stakeLockedRewardedTokens`
+
+## Unstake Tokens
+
+TODO
+- Uses `unstakeLockedTokens`
+
+## Withdraw Unbonded Tokens
+
+TODO
+- Uses `withdrawLockedUnbondedTokens`
+
+## Withdraw Rewarded Tokens
+
+TODO
+- Uses `withdrawLockedRewardedTokens`

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -20,11 +20,15 @@ Both parties have separate roles in this relationship:
 - **Node Operator:** Manages the node infrastructure but _does not hold_ any FLOW tokens.
 - **Token Holder:** Provides restricted, indirect access to their FLOW tokens for the sole purpose of staking.
 
-This guide assumes that the **token holder** has already estabilished a relationship with a trusted **node operator**.
+This guide assumes that the **token holder** has already established a 
+trusted relationship with a **node operator**.
 
 # Setup
 
 These are the steps required to set up the integration between a **token holder** and a **node operator**.
+
+_Note: The corresponding **node operator** steps are outlined in a 
+[separate guide for node operators](/token/staking2/node-operators)._
 
 ## 1. Fetch Node Operator information
 

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -31,46 +31,112 @@ _Note: The corresponding **node operator** steps are outlined in a
 [separate guide for node operators](/token/staking2/node-operators)._
 
 ## 1. Fetch node operator information
+After a node operator has agreed to run a node for you, they will create a NodeInfo object holding the IP address and public keys for your new node. This NodeInfo object will be stored in an account owned by the node operator.
 
-TODO
-- Provide `operatorAddress, nodeID`
-- Uses `TH.04` script
+The node operator should provide you with their account address and the nodeID for your new node. These parameters can be passed into the get_node_info script (TH.04) to confirm the node information.
+
+If the node information is correct, continue to step 2.
+
+To fetch the node operator information for an address's staking proxy, the token holder must use use script [../transactions/#staking-with-lockboxnodestakerproxy](TH.04):
+
+`stakingProxy/sh_get_node_info.cdc`
+
+Script arguments:
+
+| Argument     | Type    | Purpose |
+|--------------|---------|---------|
+| **account**  | Address | The address of the node operator's account. |
+| **nodeID**   | String  | The unique id of the node. |
+
+Script returns:
+
+The `StakingProxy.NodeInfo` struct containing the details for the node. If no NodeInfo is available, the script will fail.
 
 ## 2. Register node & grant staking access to the node operator
 
-TODO
-- Provide `amount` to be staked
-- Provide `operatorAddress, nodeID` to stake to
-- Uses `TH.05` transaction
+To register the node as the token holder account's staker, the token holder must use  use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.05):
+
+`stakingProxy/sh_register_node.cdc`
+
+Transaction arguments:
+
+| Argument    | Type    | Purpose |
+|-------------|---------|---------|
+| **address** | Address | The node operator address. |
+| **nodeID**  | String  | The `id` from the NodeInfo. |
+| **amount**  | UFix64  | The number of FLOW tokens to stake. |
 
 # Staking Actions
 
 ## Stake New Tokens
 
-TODO
-- Uses `TH.06` transaction
+To stake new tokens via the proxy, the token holder must use use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.06):
+
+`lockedTokens/staker/stake_new_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **amount** | UFix64 | The quantity of new FLOW tokens to add to the user's stake. |
+
 
 ## Stake Unbonded Tokens
 
-TODO
-- Uses `TH.07` transaction
+To stake unbonded tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
+
+`lockedTokens/staker/stake_unlocked_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **amount** | UFix64 | The quantity of unbonded FLOW tokens to add to the user's stake. |
 
 ## Stake Rewarded Tokens
 
-TODO
-- Uses `TH.08` transaction
+To stake rewarded tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.08):
+
+`lockedTokens/staker/stake_rewarded_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **amount** | UFix64 | The quantity of rewarded FLOW tokens to add to the user's stake. |
 
 ## Unstake Tokens
 
-TODO
-- Uses `TH.09` transaction
+To unstake their tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.09):
+
+`lockedTokens/staker/unstake_all.cdc`
+
+Transaction arguments:
+
+None.
+
+**Note that this will unstake all of the user's staked tokens.**
 
 ## Withdraw Unbonded Tokens
 
-TODO
-- Uses `TH.10` transaction
+To withdraw unbonded tokens (tokens that were previously staked and then unstaked) via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.10):
+
+`lockedTokens/staker/withdraw_unlocked_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **amount** | UFix64 | The quantity of unbonded FLOW tokens to withdraw from the proxy. |
 
 ## Withdraw Rewarded Tokens
 
-TODO
-- Uses `TH.11` transaction
+To withdraw rewarded tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.11):
+
+`lockedTokens/staker/withdraw_rewarded_tokens.cdc`
+
+Transaction arguments:
+
+| Argument   | Type   | Purpose |
+|------------|--------|---------|
+| **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw from the proxy. |

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -23,50 +23,50 @@ sidebar_title: Transactions Reference
 
 ### Token Admin (TA)
 
-- **TA.01**: createAdminAccount (with `TokenAdminCollection`)
-- **TA.02**: createLockedAccount
-- **TA.03**: createUnlockedAccount
-- **TA.04**: depositLockedTokens
-- **TA.05**: increaseUnlockLimit
+- **`TA.01`**: createAdminAccount (with `TokenAdminCollection`)
+- **`TA.02`**: createLockedAccount
+- **`TA.03`**: createUnlockedAccount
+- **`TA.04`**: depositLockedTokens
+- **`TA.05`**: increaseUnlockLimit
 
 ### Token Holder (TH)
 
-- **TH.01**: withdrawUnlockedTokens
+- **`TH.01`**: withdrawUnlockedTokens
 
 #### Staking (with `Lockbox.NodeStakerProxy`)
 
-- **TH.03**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **TH.04**: registerNode
-- **TH.05**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **TH.06**: stakeLockedRewardedTokens
+- **`TH.03`**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **`TH.04`**: registerNode
+- **`TH.05`**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **`TH.06`**: stakeLockedRewardedTokens
 
 #### Delegating (with `Lockbox.NodeDelegatorProxy`)
 
-- **TH.07**: registerLockedDelegator
-- **TH.08**: delegateNewLockedTokens
-- **TH.09**: delegateLockedUnbondedTokens
-- **TH.10**: delegateLockedRewardedTokens
-- **TH.11**: requestUnstakingLockedDelegatedTokens
-- **TH.12**: unstakeAllLockedDelegatedTokens
-- **TH.13**: withdrawLockedUnbondedDelegatedTokens
-- **TH.14**: withdrawLockedRewardedDelegatedTokens
+- **`TH.07`**: registerLockedDelegator
+- **`TH.08`**: delegateNewLockedTokens
+- **`TH.09`**: delegateLockedUnbondedTokens
+- **`TH.10`**: delegateLockedRewardedTokens
+- **`TH.11`**: requestUnstakingLockedDelegatedTokens
+- **`TH.12`**: unstakeAllLockedDelegatedTokens
+- **`TH.13`**: withdrawLockedUnbondedDelegatedTokens
+- **`TH.14`**: withdrawLockedRewardedDelegatedTokens
 
 ### Token Holder or Node Operator (TH-NO)
 
 #### Staking (with `Lockbox.NodeStakerProxy`)
 
-- **TH-NO.01**: stakeNewLockedTokens
-- **TH-NO.02**: stakeLockedUnbondedTokens
+- **`TH-NO.01`**: stakeNewLockedTokens
+- **`TH-NO.02`**: stakeLockedUnbondedTokens
 - ~~stakeLockedRewardedTokens~~ _Can only be performed by Token Holder._
-- **TH-NO.03**: unstakeLockedTokens
-- **TH-NO.04**: withdrawLockedUnbondedTokens
-- **TH-NO.05**: withdrawLockedRewardedTokens
+- **`TH-NO.03`**: unstakeLockedTokens
+- **`TH-NO.04`**: withdrawLockedUnbondedTokens
+- **`TH-NO.05`**: withdrawLockedRewardedTokens
 
 ### Node Operator (NO)
 
-- **NO.01**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
+- **`NO.01`**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
 
 #### Staking
 
-- **NO.02**: addNodeInfo
-- **NO.03**: removeNodeInfo
+- **`NO.02`**: addNodeInfo
+- **`NO.03`**: removeNodeInfo

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -23,6 +23,14 @@ sidebar_title: Transactions Reference
 
 ## Token Admin (TA)
 
+The **token admin** is the administrator responsible for distributing and 
+releasing locked FLOW tokens. The **token admin** has possession of a single 
+account that is used to control the lockups for all locked FLOW.
+
+The **token admin** creates a **shared account** for each **token holder**
+that is co-owned by the **token admin** and the **token holder**. 
+The **shared account** is used to store all locked FLOW owned by a **token holder**. 
+
 - **`TA.01`**: createAdminAccount (with `TokenAdminCollection`)
 - **`TA.02`**: createLockedAccount
 - **`TA.03`**: createUnlockedAccount
@@ -31,38 +39,41 @@ sidebar_title: Transactions Reference
 
 ## Token Holder (TH)
 
+The **token holder** is a user who holds possession of 
+locked and unlocked FLOW tokens.
+
+The **token holder** can stake and delegate locked or unlocked FLOW
+through the `StakingProxy` contract.
+
+The **token holder** can withdraw unlocked FLOW from the shared account created 
+by the token admin.
+
 - **`TH.01`**: withdrawUnlockedTokens
 
 ### Staking (with `Lockbox.NodeStakerProxy`)
 
-- **`TH.03`**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **`TH.04`**: registerNode
-- **`TH.05`**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **`TH.06`**: stakeLockedRewardedTokens
+- **`TH.02`**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **`TH.03`**: registerNode
+- **`TH.04`**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **`TH.05`**: stakeLockedRewardedTokens
+
+_Note: The remaining staking actions are [defined below](#token-holder-or-node-operator-th-no)._
 
 ### Delegating (with `Lockbox.NodeDelegatorProxy`)
 
-- **`TH.07`**: registerLockedDelegator
-- **`TH.08`**: delegateNewLockedTokens
-- **`TH.09`**: delegateLockedUnbondedTokens
-- **`TH.10`**: delegateLockedRewardedTokens
-- **`TH.11`**: requestUnstakingLockedDelegatedTokens
-- **`TH.12`**: unstakeAllLockedDelegatedTokens
-- **`TH.13`**: withdrawLockedUnbondedDelegatedTokens
-- **`TH.14`**: withdrawLockedRewardedDelegatedTokens
-
-## Token Holder or Node Operator (TH-NO)
-
-### Staking (with `Lockbox.NodeStakerProxy`)
-
-- **`TH-NO.01`**: stakeNewLockedTokens
-- **`TH-NO.02`**: stakeLockedUnbondedTokens
-- ~~stakeLockedRewardedTokens~~ _Can only be performed by Token Holder._
-- **`TH-NO.03`**: unstakeLockedTokens
-- **`TH-NO.04`**: withdrawLockedUnbondedTokens
-- **`TH-NO.05`**: withdrawLockedRewardedTokens
+- **`TH.06`**: registerLockedDelegator
+- **`TH.07`**: delegateNewLockedTokens
+- **`TH.08`**: delegateLockedUnbondedTokens
+- **`TH.09`**: delegateLockedRewardedTokens
+- **`TH.10`**: requestUnstakingLockedDelegatedTokens
+- **`TH.11`**: unstakeAllLockedDelegatedTokens
+- **`TH.12`**: withdrawLockedUnbondedDelegatedTokens
+- **`TH.13`**: withdrawLockedRewardedDelegatedTokens
 
 ## Node Operator (NO)
+
+The **node operator** is an independent user who operators a Flow node on
+behalf of a **token holder**.
 
 - **`NO.01`**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
 
@@ -70,3 +81,21 @@ sidebar_title: Transactions Reference
 
 - **`NO.02`**: addNodeInfo
 - **`NO.03`**: removeNodeInfo
+
+## Token Holder or Node Operator (TH-NO)
+
+Both the **token holder** and **node operator** can perform the following
+staking actions using locked or unlocked FLOW owned by the **token holder**.
+
+_Note: The **node operator** can perform these actions on behalf of 
+the **token holder**, but only with explicit permission. 
+This permission can be revoked by the **token holder**._
+
+### Staking (with `Lockbox.NodeStakerProxy`)
+
+- **`TH-NO.01`**: stakeNewLockedTokens
+- **`TH-NO.02`**: stakeLockedUnbondedTokens
+- ~~stakeLockedRewardedTokens~~ _Can only be performed by **token holder**._
+- **`TH-NO.03`**: unstakeLockedTokens
+- **`TH-NO.04`**: withdrawLockedUnbondedTokens
+- **`TH-NO.05`**: withdrawLockedRewardedTokens

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -32,7 +32,7 @@ The **shared account** is used to store all locked FLOW owned by a **token holde
 
 | ID | Name | Source |
 |----|------|--------|
-|**`TA.01`**| Set Up Admin Account      | `lockedTokens/admin/create_admin_collection.cdc` |
+|**`TA.01`**| Set Up Admin Account     | `lockedTokens/admin/create_admin_collection.cdc` |
 |**`TA.02`**| Created Shared Account   | `lockedTokens/admin/create_shared_account.cdc` |
 |**`TA.04`**| Deposit Locked Tokens    | `lockedTokens/admin/deposit_locked_tokens.cdc` |
 |**`TA.05`**| Unlock Tokens            | `lockedTokens/admin/unlock_tokens.cdc` |

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -3,25 +3,25 @@ title: Flow Staking Transactions Reference
 sidebar_title: Transactions Reference
 ---
 
-## Overview
+# Overview
 
-### Personas
+## Personas
 
 - Token Admin (TA)
 - Token Holder (TH)
 - Node Operator (NO)
 - Token Holder/Operator (TH-NO)
 
-### Use Cases
+## Use Cases
 
 1. TH-NO stakes directly
 1. TH delegates directly
 1. NO operates a node with StakingHelper
 1. TH stake with StakingHelper
 
-## Transactions
+# Transactions
 
-### Token Admin (TA)
+## Token Admin (TA)
 
 - **`TA.01`**: createAdminAccount (with `TokenAdminCollection`)
 - **`TA.02`**: createLockedAccount
@@ -29,18 +29,18 @@ sidebar_title: Transactions Reference
 - **`TA.04`**: depositLockedTokens
 - **`TA.05`**: increaseUnlockLimit
 
-### Token Holder (TH)
+## Token Holder (TH)
 
 - **`TH.01`**: withdrawUnlockedTokens
 
-#### Staking (with `Lockbox.NodeStakerProxy`)
+### Staking (with `Lockbox.NodeStakerProxy`)
 
 - **`TH.03`**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
 - **`TH.04`**: registerNode
 - **`TH.05`**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
 - **`TH.06`**: stakeLockedRewardedTokens
 
-#### Delegating (with `Lockbox.NodeDelegatorProxy`)
+### Delegating (with `Lockbox.NodeDelegatorProxy`)
 
 - **`TH.07`**: registerLockedDelegator
 - **`TH.08`**: delegateNewLockedTokens
@@ -51,9 +51,9 @@ sidebar_title: Transactions Reference
 - **`TH.13`**: withdrawLockedUnbondedDelegatedTokens
 - **`TH.14`**: withdrawLockedRewardedDelegatedTokens
 
-### Token Holder or Node Operator (TH-NO)
+## Token Holder or Node Operator (TH-NO)
 
-#### Staking (with `Lockbox.NodeStakerProxy`)
+### Staking (with `Lockbox.NodeStakerProxy`)
 
 - **`TH-NO.01`**: stakeNewLockedTokens
 - **`TH-NO.02`**: stakeLockedUnbondedTokens
@@ -62,11 +62,11 @@ sidebar_title: Transactions Reference
 - **`TH-NO.04`**: withdrawLockedUnbondedTokens
 - **`TH-NO.05`**: withdrawLockedRewardedTokens
 
-### Node Operator (NO)
+## Node Operator (NO)
 
 - **`NO.01`**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
 
-#### Staking
+### Staking
 
 - **`NO.02`**: addNodeInfo
 - **`NO.03`**: removeNodeInfo

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -10,14 +10,13 @@ sidebar_title: Transactions Reference
 - Token Admin (TA)
 - Token Holder (TH)
 - Node Operator (NO)
-- Token Holder/Operator (TH-NO)
 
 ## Use Cases
 
-1. TH-NO stakes directly
-1. TH delegates directly
-1. NO operates a node with StakingHelper
-1. TH stake with StakingHelper
+1. TH stakes directly to their own node
+1. TH delegates directly to another node
+1. NO operates a staked node
+1. TH stakes to a node operated by a NO
 
 # Transactions
 
@@ -31,11 +30,12 @@ The **token admin** creates a **shared account** for each **token holder**
 that is co-owned by the **token admin** and the **token holder**. 
 The **shared account** is used to store all locked FLOW owned by a **token holder**. 
 
-- **`TA.01`**: createAdminAccount (with `TokenAdminCollection`)
-- **`TA.02`**: createLockedAccount
-- **`TA.03`**: createUnlockedAccount
-- **`TA.04`**: depositLockedTokens
-- **`TA.05`**: increaseUnlockLimit
+| ID | Name | Source |
+|----|------|--------|
+|**`TA.01`**| Set Up Admin Account      | `lockedTokens/admin/create_admin_collection.cdc` |
+|**`TA.02`**| Created Shared Account   | `lockedTokens/admin/create_shared_account.cdc` |
+|**`TA.04`**| Deposit Locked Tokens    | `lockedTokens/admin/deposit_locked_tokens.cdc` |
+|**`TA.05`**| Unlock Tokens            | `lockedTokens/admin/unlock_tokens.cdc` |
 
 ## Token Holder (TH)
 
@@ -48,54 +48,63 @@ through the `StakingProxy` contract.
 The **token holder** can withdraw unlocked FLOW from the shared account created 
 by the token admin.
 
-- **`TH.01`**: withdrawUnlockedTokens
+| ID | Name | Source |
+|----|------|--------|
+|**`TH.01`**| Withdraw Unlocked FLOW | `lockedTokens/user/withdraw_tokens.cdc` |
+|**`TH.02`**| Deposit Unlocked FLOW  | `lockedTokens/user/deposit_tokens.cdc` |
+|**`TH.03`**| Get Unlock Limit       | `lockedTokens/user/get_unlock_limit.cdc` |
 
 ### Staking (with `Lockbox.NodeStakerProxy`)
 
-- **`TH.02`**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **`TH.03`**: registerNode
-- **`TH.04`**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
-- **`TH.05`**: stakeLockedRewardedTokens
+| ID | Name | Source |
+|----|------|--------|
+|**`TH.04`**| Get Operator Node Info       | `stakingProxy/sh_get_node_info.cdc` | 
+|**`TH.05`**| Register Node                | `stakingProxy/sh_register_node.cdc` |
+|**`TH.06`**| Stake New Locked FLOW        | `lockedTokens/staker/state_new_tokens.cdc` |
+|**`TH.07`**| Re-stake Unstaked FLOW       | `lockedTokens/staker/state_unlocked_tokens.cdc` |
+|**`TH.08`**| Re-stake Rewarded FLOW       | `lockedTokens/staker/state_rewarded_tokens.cdc` |
+|**`TH.09`**| Unstake FLOW                 | `lockedTokens/staker/unstake_all.cdc` |
+|**`TH.10`**| Withdraw Unstaked FLOW       | `lockedTokens/staker/withdraw_unlocked_tokens.cdc` |
+|**`TH.11`**| Withdraw Rewarded FLOW       | `lockedTokens/staker/withdraw_rewarded_tokens.cdc` |
 
-_Note: The remaining staking actions are [defined below](#token-holder-or-node-operator-th-no)._
 
 ### Delegating (with `Lockbox.NodeDelegatorProxy`)
 
-- **`TH.06`**: registerLockedDelegator
-- **`TH.07`**: delegateNewLockedTokens
-- **`TH.08`**: delegateLockedUnbondedTokens
-- **`TH.09`**: delegateLockedRewardedTokens
-- **`TH.10`**: requestUnstakingLockedDelegatedTokens
-- **`TH.11`**: unstakeAllLockedDelegatedTokens
-- **`TH.12`**: withdrawLockedUnbondedDelegatedTokens
-- **`TH.13`**: withdrawLockedRewardedDelegatedTokens
+| ID | Name | Source |
+|----|------|--------|
+|**`TH.11`**| Register Delegator        | `lockedTokens/delegator/register_delegator.cdc` |
+|**`TH.12`**| Delegate New Locked FLOW  | `lockedTokens/delegator/delegate_new_locked_tokens.cdc` |
+|**`TH.13`**| Re-delegate Unstaked FLOW | `lockedTokens/delegator/delegate_locked_unlocked_tokens.cdc` | 
+|**`TH.14`**| Re-delegate Rewarded FLOW | `lockedTokens/delegator/delegate_locked_rewarded_tokens.cdc` |
+|**`TH.15`**| Unstake Delegated FOW     | `lockedTokens/delegator/request_unstaking_locked_delegated_tokens.cdc` |
+|**`TH.16`**| Withdraw Unstaked FLOW    | `lockedTokens/delegator/withdraw_locked_unlocked_delegated_tokens` |
+|**`TH.17`**| Withdraw Rewarded FLOW    | `lockedTokens/delegator/withdraw_locked_rewarded_delegated_tokens.cdc` |
 
 ## Node Operator (NO)
 
 The **node operator** is an independent user who operators a Flow node on
 behalf of a **token holder**.
 
-- **`NO.01`**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
+| ID | Name | Source |
+|----|------|--------|
+|**`NO.01`**| Set Up Operator Account | `stakingProxy/sh_setup_node_account.cdc` | 
 
-### Staking
+### Staking (with `StakingProxy.NodeStakerProxy`)
 
-- **`NO.02`**: addNodeInfo
-- **`NO.03`**: removeNodeInfo
-
-## Token Holder or Node Operator (TH-NO)
-
-Both the **token holder** and **node operator** can perform the following
+The  **node operator** can perform the following
 staking actions using locked or unlocked FLOW owned by the **token holder**.
 
 _Note: The **node operator** can perform these actions on behalf of 
 the **token holder**, but only with explicit permission. 
 This permission can be revoked by the **token holder**._
 
-### Staking (with `Lockbox.NodeStakerProxy`)
-
-- **`TH-NO.01`**: stakeNewLockedTokens
-- **`TH-NO.02`**: stakeLockedUnbondedTokens
-- ~~stakeLockedRewardedTokens~~ _Can only be performed by **token holder**._
-- **`TH-NO.03`**: unstakeLockedTokens
-- **`TH-NO.04`**: withdrawLockedUnbondedTokens
-- **`TH-NO.05`**: withdrawLockedRewardedTokens
+| ID | Name | Source |
+|----|------|--------|
+|**`NO.02`**| Add Node Info          | `stakingProxy/sh_add_node_info.cdc` | 
+|**`NO.03`**| Remove Node Info       | `stakingProxy/sh_remove_node_info.cdc` | 
+|**`NO.04`**| Remove Staking Proxy   | `stakingProxy/sh_remove_staking_proxy.cdc` | 
+|**`NO.05`**| Stake New Locked FLOW  | `stakingProxy/sh_stake_new_tokens.cdc` | 
+|**`NO.06`**| Re-stake Unstaked FLOW | `stakingProxy/sh_stake_unlocked_tokens.cdc` | 
+|**`NO.07`**| Unstake FLOW           | `stakingProxy/sh_unstake_all.cdc` | 
+|**`NO.08`**| Withdraw Unstaked FLOW | `stakingProxy/sh_withdraw_unlocked.cdc` | 
+|**`NO.09`**| Withdraw Rewarded FLOW | `stakingProxy/sh_withdraw_rewards.cdc` | 

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -1,0 +1,72 @@
+---
+title: Flow Staking Transactions Reference
+sidebar_title: Transactions Reference
+---
+
+## Overview
+
+### Personas
+
+- Token Admin (TA)
+- Token Holder (TH)
+- Node Operator (NO)
+- Token Holder/Operator (TH-NO)
+
+### Use Cases
+
+1. TH-NO stakes directly
+1. TH delegates directly
+1. NO operates a node with StakingHelper
+1. TH stake with StakingHelper
+
+## Transactions
+
+### Token Admin (TA)
+
+- **TA.01**: createAdminAccount (with `TokenAdminCollection`)
+- **TA.02**: createLockedAccount
+- **TA.03**: createUnlockedAccount
+- **TA.04**: depositLockedTokens
+- **TA.05**: increaseUnlockLimit
+
+### Token Holder (TH)
+
+- **TH.01**: withdrawUnlockedTokens
+
+#### Staking (with `Lockbox.NodeStakerProxy`)
+
+- **TH.03**: getOperatorNodeInfo (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **TH.04**: registerNode
+- **TH.05**: addStakingProxy (with `StakingProxy.NodeStakerProxyHolderPublic`)
+- **TH.06**: stakeLockedRewardedTokens
+
+#### Delegating (with `Lockbox.NodeDelegatorProxy`)
+
+- **TH.07**: registerLockedDelegator
+- **TH.08**: delegateNewLockedTokens
+- **TH.09**: delegateLockedUnbondedTokens
+- **TH.10**: delegateLockedRewardedTokens
+- **TH.11**: requestUnstakingLockedDelegatedTokens
+- **TH.12**: unstakeAllLockedDelegatedTokens
+- **TH.13**: withdrawLockedUnbondedDelegatedTokens
+- **TH.14**: withdrawLockedRewardedDelegatedTokens
+
+### Token Holder or Node Operator (TH-NO)
+
+#### Staking (with `Lockbox.NodeStakerProxy`)
+
+- **TH-NO.01**: stakeNewLockedTokens
+- **TH-NO.02**: stakeLockedUnbondedTokens
+- ~~stakeLockedRewardedTokens~~ _Can only be performed by Token Holder._
+- **TH-NO.03**: unstakeLockedTokens
+- **TH-NO.04**: withdrawLockedUnbondedTokens
+- **TH-NO.05**: withdrawLockedRewardedTokens
+
+### Node Operator (NO)
+
+- **NO.01**: createOperatorAccount (with `StakingProxy.NodeStakerProxyHolder`)
+
+#### Staking
+
+- **NO.02**: addNodeInfo
+- **NO.03**: removeNodeInfo

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -67,18 +67,17 @@ by the token admin.
 |**`TH.10`**| Withdraw Unstaked FLOW       | `lockedTokens/staker/withdraw_unlocked_tokens.cdc` |
 |**`TH.11`**| Withdraw Rewarded FLOW       | `lockedTokens/staker/withdraw_rewarded_tokens.cdc` |
 
-
 ### Delegating (with `Lockbox.NodeDelegatorProxy`)
 
 | ID | Name | Source |
 |----|------|--------|
-|**`TH.11`**| Register Delegator        | `lockedTokens/delegator/register_delegator.cdc` |
-|**`TH.12`**| Delegate New Locked FLOW  | `lockedTokens/delegator/delegate_new_locked_tokens.cdc` |
-|**`TH.13`**| Re-delegate Unstaked FLOW | `lockedTokens/delegator/delegate_locked_unlocked_tokens.cdc` | 
-|**`TH.14`**| Re-delegate Rewarded FLOW | `lockedTokens/delegator/delegate_locked_rewarded_tokens.cdc` |
-|**`TH.15`**| Unstake Delegated FOW     | `lockedTokens/delegator/request_unstaking_locked_delegated_tokens.cdc` |
-|**`TH.16`**| Withdraw Unstaked FLOW    | `lockedTokens/delegator/withdraw_locked_unlocked_delegated_tokens` |
-|**`TH.17`**| Withdraw Rewarded FLOW    | `lockedTokens/delegator/withdraw_locked_rewarded_delegated_tokens.cdc` |
+|**`TH.12`**| Register Delegator        | `lockedTokens/delegator/register_delegator.cdc` |
+|**`TH.13`**| Delegate New Locked FLOW  | `lockedTokens/delegator/delegate_new_locked_tokens.cdc` |
+|**`TH.14`**| Re-delegate Unstaked FLOW | `lockedTokens/delegator/delegate_locked_unlocked_tokens.cdc` | 
+|**`TH.15`**| Re-delegate Rewarded FLOW | `lockedTokens/delegator/delegate_locked_rewarded_tokens.cdc` |
+|**`TH.16`**| Unstake Delegated FOW     | `lockedTokens/delegator/request_unstaking_locked_delegated_tokens.cdc` |
+|**`TH.17`**| Withdraw Unstaked FLOW    | `lockedTokens/delegator/withdraw_locked_unlocked_delegated_tokens` |
+|**`TH.18`**| Withdraw Rewarded FLOW    | `lockedTokens/delegator/withdraw_locked_rewarded_delegated_tokens.cdc` |
 
 ## Node Operator (NO)
 

--- a/docs/content/token/staking2/transactions.mdx
+++ b/docs/content/token/staking2/transactions.mdx
@@ -60,11 +60,11 @@ by the token admin.
 |----|------|--------|
 |**`TH.04`**| Get Operator Node Info       | `stakingProxy/sh_get_node_info.cdc` | 
 |**`TH.05`**| Register Node                | `stakingProxy/sh_register_node.cdc` |
-|**`TH.06`**| Stake New Locked FLOW        | `lockedTokens/staker/state_new_tokens.cdc` |
-|**`TH.07`**| Re-stake Unstaked FLOW       | `lockedTokens/staker/state_unlocked_tokens.cdc` |
-|**`TH.08`**| Re-stake Rewarded FLOW       | `lockedTokens/staker/state_rewarded_tokens.cdc` |
+|**`TH.06`**| Stake New Locked FLOW        | `lockedTokens/staker/stake_new_tokens.cdc` |
+|**`TH.07`**| Re-stake Unstaked FLOW       | `lockedTokens/staker/stake_unstaked_tokens.cdc` |
+|**`TH.08`**| Re-stake Rewarded FLOW       | `lockedTokens/staker/stake_rewarded_tokens.cdc` |
 |**`TH.09`**| Unstake FLOW                 | `lockedTokens/staker/unstake_all.cdc` |
-|**`TH.10`**| Withdraw Unstaked FLOW       | `lockedTokens/staker/withdraw_unlocked_tokens.cdc` |
+|**`TH.10`**| Withdraw Unstaked FLOW       | `lockedTokens/staker/withdraw_unstaked_tokens.cdc` |
 |**`TH.11`**| Withdraw Rewarded FLOW       | `lockedTokens/staker/withdraw_rewarded_tokens.cdc` |
 
 ### Delegating (with `Lockbox.NodeDelegatorProxy`)
@@ -73,10 +73,10 @@ by the token admin.
 |----|------|--------|
 |**`TH.12`**| Register Delegator        | `lockedTokens/delegator/register_delegator.cdc` |
 |**`TH.13`**| Delegate New Locked FLOW  | `lockedTokens/delegator/delegate_new_locked_tokens.cdc` |
-|**`TH.14`**| Re-delegate Unstaked FLOW | `lockedTokens/delegator/delegate_locked_unlocked_tokens.cdc` | 
+|**`TH.14`**| Re-delegate Unstaked FLOW | `lockedTokens/delegator/delegate_locked_unstaked_tokens.cdc` | 
 |**`TH.15`**| Re-delegate Rewarded FLOW | `lockedTokens/delegator/delegate_locked_rewarded_tokens.cdc` |
 |**`TH.16`**| Unstake Delegated FOW     | `lockedTokens/delegator/request_unstaking_locked_delegated_tokens.cdc` |
-|**`TH.17`**| Withdraw Unstaked FLOW    | `lockedTokens/delegator/withdraw_locked_unlocked_delegated_tokens` |
+|**`TH.17`**| Withdraw Unstaked FLOW    | `lockedTokens/delegator/withdraw_locked_unstaked_delegated_tokens` |
 |**`TH.18`**| Withdraw Rewarded FLOW    | `lockedTokens/delegator/withdraw_locked_rewarded_delegated_tokens.cdc` |
 
 ## Node Operator (NO)
@@ -103,7 +103,7 @@ This permission can be revoked by the **token holder**._
 |**`NO.03`**| Remove Node Info       | `stakingProxy/sh_remove_node_info.cdc` | 
 |**`NO.04`**| Remove Staking Proxy   | `stakingProxy/sh_remove_staking_proxy.cdc` | 
 |**`NO.05`**| Stake New Locked FLOW  | `stakingProxy/sh_stake_new_tokens.cdc` | 
-|**`NO.06`**| Re-stake Unstaked FLOW | `stakingProxy/sh_stake_unlocked_tokens.cdc` | 
+|**`NO.06`**| Re-stake Unstaked FLOW | `stakingProxy/sh_stake_unstaked_tokens.cdc` | 
 |**`NO.07`**| Unstake FLOW           | `stakingProxy/sh_unstake_all.cdc` | 
-|**`NO.08`**| Withdraw Unstaked FLOW | `stakingProxy/sh_withdraw_unlocked.cdc` | 
+|**`NO.08`**| Withdraw Unstaked FLOW | `stakingProxy/sh_withdraw_unstaked.cdc` | 
 |**`NO.09`**| Withdraw Rewarded FLOW | `stakingProxy/sh_withdraw_rewards.cdc` | 

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -312,7 +312,7 @@ const sections = [
         "docs/language/built-in-functions",
         "docs/language/environment-information",
         "docs/language/crypto",
-        "docs/language/type-hierarchy",
+        "docs/language/type-hierarchy"
       ],
     },
   },

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -257,6 +257,14 @@ const sections = [
         "token/staking/node-operators",
         "token/staking/staking-as-a-service",
       ],
+      Staking2: [
+        "token/staking2/index",
+        "token/staking2/stakers",
+        "token/staking2/delegators",
+        "token/staking2/node-operators",
+        "token/staking2/power-users",
+        "token/staking2/transactions",
+      ],
     },
   },
   {


### PR DESCRIPTION
## Description

Adds instructions for custody providers to create locked token accounts for their users.
Probably needs more details and transaction labels like we have for the other transactions.