### PR TITLE
Adds account creation doc

### DIFF
--- a/docs/content/token/staking2/setup.mdx
+++ b/docs/content/token/staking2/setup.mdx
@@ -3,7 +3,104 @@ title: Configure an Account to Receive Locked FLOW
 sidebar_title: Account Setup
 ---
 
-TODO
-- custody_create_only_shared_account.cdc
-- custody_create_shared_accounts.cdc
-- custody_setup_account_creator.cdc
+<Callout type="warning">
+
+  This guide is for custody providers or wallet providers to create user accounts 
+  that can hold locked tokens from the Flow token sale.
+  If you already have an account and wish to stake tokens, see other sections of the staking docs.
+
+</Callout>
+
+# Introduction
+
+This guide covers the technical integration required for custody providers to create
+accounts that store locked tokens for users.
+
+Every user who holds locked tokens gets two accounts.
+
+- **Account One - Shared Account:** This account is shared between the Flow token admin and the user.
+The user's key will have weight 900 and the token admin's key will have weight 100.
+Therefore, any transactions that directly access this account need to be signed by both parties.
+The locked tokens are stored in this account and the token admin has the authority to unlock
+tokens as outlined by the vesting schedule. This account also manages access to the staking
+and delegating functionality that a user signs up for.
+- **Account Two - Unlocked Account:** This account is completely controlled by the user.
+It includes an object that manages access to the functionality contained in the shared account.
+The user submits token withdrawal and staking transactions with this account.
+
+# Setup
+
+To enable your custody account to create accounts with locked tokens, you must
+run the transaction
+
+`lockedTokens/admin/custody_setup_account_creator.cdc`
+
+Transaction arguments:
+
+None.
+
+This transaction creates an `AccountCreator` object and stores it in the custody provider's account.
+It also publishes a capability that allows the token admin to give the custody provider 
+the authority to register locked token accounts.
+
+# Account Creation
+
+When a custody provider uses these transactions, they must also ensure that 
+the token admin knows which account addresses map to which users. This is so 
+the token admin knows how much to pay to each locked account
+and how many tokens to unlock via the vesting schedule.
+
+## 1. Creating Both Accounts for the user
+
+If your user does not have a regular account created for them yet, you must 
+create both accounts in a single transaction.
+
+`lockedTokens/admin/custody_create_shared_accounts.cdc`
+
+Transaction arguments:
+
+| Argument                  | Type    | Purpose |
+|---------------------------|---------|---------|
+| **partialAdminPublicKey** | [UInt8] | The public key of the token admin. Must be Weight: 100 |
+| **partialUserPublicKey**  | [UInt8] | The public key of the user. Must be Weight: 900 |
+| **fullUserPublicKey**     | [UInt8] | The public key of the user. Must be Weight: 1000 |
+
+
+## 2. Creating the Shared account for a user who already has a personal account
+
+If your user already has a personal account allocated to them, you can run a transaction
+that creates the shared account and gives their existing account the capability
+to interact with their locked tokens. 
+
+<Callout type="warning">
+
+  This transaction **MUST** also be signed and authorized by the existing user account.
+  It needs this because it needs to have access to the user's private storage and Authorized access.
+
+</Callout>
+
+`lockedTokens/admin/custody_create_only_shared_account.cdc`
+
+Transaction arguments:
+
+| Argument                  | Type    | Purpose |
+|---------------------------|---------|---------|
+| **partialAdminPublicKey** | [UInt8] | The public key of the token admin. Must be Weight: 100 |
+| **partialUserPublicKey**  | [UInt8] | The public key of the user. Must be Weight: 900 |
+
+
+Both transactions generally perform the same actions:
+
+1. Create the shared account and add the partial public keys to the account.
+2. Create the Locked Token Manager object in the shared account.
+3. Create the Token Holder object and store it in the user account. This object
+is what the user interacts with to withdraw unlocked tokens and perform staking actions.
+4. Register the new accounts with the token admin account so that 
+it can receive locked tokens from the vesting schedule.
+5. Override the default Flow Token receiver to mark received tokens as unlocked.
+6. Create a different Flow Token receiver that the token admin account uses to deposit locked tokens.
+
+
+
+
+

--- a/docs/content/token/staking2/setup.mdx
+++ b/docs/content/token/staking2/setup.mdx
@@ -43,6 +43,22 @@ This transaction creates an `AccountCreator` object and stores it in the custody
 It also publishes a capability that allows the token admin to give the custody provider 
 the authority to register locked token accounts.
 
+## Receive Account creator Capability
+
+After you have set up your account, the token admin needs to submit one more transaction
+to enable your account to register new user accounts to receive locked tokens.
+
+This transaction needs to be signed and authorized by the token admin account.
+
+`lockedTokens/admin/admin_deposit_account_creator.cdc`
+
+| Argument                    | Type    | Purpose |
+|-----------------------------|---------|---------|
+| **custodyProviderAddress**  | Address | The address of the custody provider's account. |
+
+This transaction gives the account registration capability to the custody provider's account
+that was set up in the previous transaction.
+
 # Account Creation
 
 When a custody provider uses these transactions, they must also ensure that 

--- a/docs/content/token/staking2/stakers.mdx
+++ b/docs/content/token/staking2/stakers.mdx
@@ -31,13 +31,16 @@ _Note: The corresponding **node operator** steps are outlined in a
 [separate guide for node operators](/token/staking2/node-operators)._
 
 ## 1. Fetch node operator information
-After a node operator has agreed to run a node for you, they will create a NodeInfo object holding the IP address and public keys for your new node. This NodeInfo object will be stored in an account owned by the node operator.
+After a node operator has agreed to run a node for you, they will create a NodeInfo object holding the IP address and public keys for your new node. 
+This NodeInfo object will be stored in an account owned by the node operator. This object acts as a staking proxy 
+for the node operator to access some staking options without actually having access to your tokens.
 
-The node operator should provide you with their account address and the nodeID for your new node. These parameters can be passed into the get_node_info script (TH.04) to confirm the node information.
+The node operator should provide you with their account address and the nodeID for your new node. 
+These parameters can be passed into the get_node_info script (TH.04) to confirm the node information.
 
 If the node information is correct, continue to step 2.
 
-To fetch the node operator information for an address's staking proxy, the token holder must use use script [../transactions/#staking-with-lockboxnodestakerproxy](TH.04):
+To fetch the node operator information for a node operator's staking proxy, the token holder must use use script [../transactions/#staking-with-lockboxnodestakerproxy](TH.04):
 
 `stakingProxy/sh_get_node_info.cdc`
 
@@ -50,7 +53,7 @@ Script arguments:
 
 Script returns:
 
-The `StakingProxy.NodeInfo` struct containing the details for the node. If no NodeInfo is available, the script will fail.
+The `StakingProxy.NodeInfo` struct contains the details for the node. If no NodeInfo is available, the script will fail.
 
 ## 2. Register node & grant staking access to the node operator
 
@@ -68,6 +71,11 @@ Transaction arguments:
 
 # Staking Actions
 
+Once the token holder has registered their node with the node operator's info, their tokens and info
+are committed to the central staking contract for the next epoch. They now have access to 
+various staking operations that they can perform at any time, assuming they have
+the correct number of tokens to perform the action.
+
 ## Stake New Tokens
 
 To stake new tokens via the proxy, the token holder must use use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.06):
@@ -80,12 +88,14 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of new FLOW tokens to add to the user's stake. |
 
+This transaction commits tokens to stake from the user's locked token account.
 
 ## Stake Unbonded Tokens
 
-To stake unbonded tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
+To stake unstaked tokens (tokens that had been previously staked but were unstaked) via the proxy, 
+the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.07):
 
-`lockedTokens/staker/stake_unlocked_tokens.cdc`
+`lockedTokens/staker/stake_unstaked_tokens.cdc`
 
 Transaction arguments:
 
@@ -105,9 +115,13 @@ Transaction arguments:
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to add to the user's stake. |
 
+Since rewarded tokens are considered to be unlocked for the purposes of the vesting schedule,
+and staked tokens are considered locked, staking rewarded tokens marks the staked tokens as locked
+and marks an equal amount of tokens in the user's locked account as unlocked.
+
 ## Unstake Tokens
 
-To unstake their tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.09):
+To unstake all of their tokens via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.09):
 
 `lockedTokens/staker/unstake_all.cdc`
 
@@ -117,11 +131,13 @@ None.
 
 **Note that this will unstake all of the user's staked tokens.**
 
-## Withdraw Unbonded Tokens
+When a user unstakes their tokens, they must wait until the end of the following epoch to be able to withdraw them.
 
-To withdraw unbonded tokens (tokens that were previously staked and then unstaked) via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.10):
+## Withdraw Unstaked Tokens
 
-`lockedTokens/staker/withdraw_unlocked_tokens.cdc`
+To withdraw unstaked tokens (tokens that were previously staked and then unstaked) via the proxy, the token holder must use transaction [../transactions/#staking-with-lockboxnodestakerproxy](TH.10):
+
+`lockedTokens/staker/withdraw_unstaked_tokens.cdc`
 
 Transaction arguments:
 
@@ -140,3 +156,6 @@ Transaction arguments:
 | Argument   | Type   | Purpose |
 |------------|--------|---------|
 | **amount** | UFix64 | The quantity of rewarded FLOW tokens to withdraw from the proxy. |
+
+Since rewards are considered to be unlocked. This marks an equal amount in your locked account as unlocked.
+You can immediately withdraw your unlocked reward tokens from your account after withdrawing rewards.


### PR DESCRIPTION
## Description

Adds instructions for custody providers to create locked token accounts for their users.
Probably needs more details and transaction labels like we have for the other transactions.e Github PR explorer