### PR TITLE
Fixed fungible token tutorial document

### DIFF
--- a/docs/content/tutorial/cadence/03-fungible-tokens.mdx
+++ b/docs/content/tutorial/cadence/03-fungible-tokens.mdx
@@ -514,167 +514,34 @@ Open the transaction named `Transaction1.cdc`. <br/>
 </Callout>
 
 
-```cadence:title=FungibleToken.cdc
-pub contract FungibleToken {
+```cadence:title=Transaction1.cdc
+import FungibleToken from 0x01
 
-    // Total supply of all tokens in existence.
-    pub var totalSupply: UFix64
+// This transaction creates a capability 
+// that is linked to the account's token vault.
+// The capability is restricted to the fields in the `Receiver` interface,
+// so it can only be used to deposit funds into the account.
+transaction {
+  prepare(acct: AuthAccount) {
 
-    // Provider
+    // Create a link to the Vault in storage that is restricted to the
+    // fields and functions in `Receiver` and `Balance` interfaces, 
+    // this only exposes the balance field 
+    // and deposit function of the underlying vault.
     //
-    // Interface that enforces the requirements for withdrawing
-    // tokens from the implementing type.
-    //
-    // We don't enforce requirements on self.balance here because
-    // it leaves open the possibility of creating custom providers
-    // that don't necessarily need their own balance.
-    //
-    pub resource interface Provider {
+    acct.link<&FungibleToken.Vault{FungibleToken.Receiver, FungibleToken.Balance}>(/public/MainReceiver, target: /storage/MainVault)
 
-        // withdraw
-        //
-        // Function that subtracts tokens from the owner's Vault
-        // and returns a Vault resource (@Vault) with the removed tokens.
-        //
-        // The function's access level is public, but this isn't a problem
-        // because even the public functions are not fully public at first.
-        // anyone in the network can call them, but only if the owner grants
-        // them access by publishing a resource that exposes the withdraw
-        // function.
-        //
-        pub fun withdraw(amount: UFix64): @Vault {
-            post {
-                // `result` refers to the return value of the function
-                result.balance == UFix64(amount):
-                    "Withdrawal amount must be the same as the balance of the withdrawn Vault"
-            }
-        }
-    }
+    log("Public Receiver reference created!")
+  }
 
-    // Receiver
-    //
-    // Interface that enforces the requirements for depositing
-    // tokens into the implementing type.
-    //
-    // We don't include a condition that checks the balance because
-    // we want to give users the ability to make custom Receivers that
-    // can do custom things with the tokens, like split them up and
-    // send them to different places.
-    //
-    pub resource interface Receiver {
-        // deposit
-        //
-        // Function that can be called to deposit tokens
-        // into the implementing resource type
-        //
-        pub fun deposit(from: @Vault) {
-            pre {
-                from.balance > UFix64(0):
-                    "Deposit balance must be positive"
-            }
-        }
-    }
-
-    // Balance
-    //
-    // Interface that specifies a public `balance` field for the vault
-    //
-    pub resource interface Balance {
-        pub var balance: UFix64
-    }
-
-    // Vault
-    //
-    // Each user stores an instance of only the Vault in their storage
-    // The functions in the Vault and governed by the pre and post conditions
-    // in the interfaces when they are called.
-    // The checks happen at runtime whenever a function is called.
-    //
-    // Resources can only be created in the context of the contract that they
-    // are defined in, so there is no way for a malicious user to create Vaults
-    // out of thin air. A special Minter resource needs to be defined to mint
-    // new tokens.
-    //
-    pub resource Vault: Provider, Receiver, Balance {
-
-        // keeps track of the total balance of the account's tokens
-        pub var balance: UFix64
-
-        // initialize the balance at resource creation time
-        init(balance: UFix64) {
-            self.balance = balance
-        }
-
-        // withdraw
-        //
-        // Function that takes an integer amount as an argument
-        // and withdraws that amount from the Vault.
-        //
-        // It creates a new temporary Vault that is used to hold
-        // the money that is being transferred. It returns the newly
-        // created Vault to the context that called so it can be deposited
-        // elsewhere.
-        //
-        pub fun withdraw(amount: UFix64): @Vault {
-            self.balance = self.balance - amount
-            return <-create Vault(balance: amount)
-        }
-
-        // deposit
-        //
-        // Function that takes a Vault object as an argument and adds
-        // its balance to the balance of the owners Vault.
-        //
-        // It is allowed to destroy the sent Vault because the Vault
-        // was a temporary holder of the tokens. The Vault's balance has
-        // been consumed and therefore can be destroyed.
-        pub fun deposit(from: @Vault) {
-            self.balance = self.balance + from.balance
-            destroy from
-        }
-    }
-
-    // createEmptyVault
-    //
-    // Function that creates a new Vault with a balance of zero
-    // and returns it to the calling context. A user must call this function
-    // and store the returned Vault in their storage in order to allow their
-    // account to be able to receive deposits of this token type.
-    //
-    pub fun createEmptyVault(): @Vault {
-        return <-create Vault(balance: UFix64(0))
-    }
-
-    // VaultMinter
-    //
-    // Resource object that an admin can control to mint new tokens
-    pub resource VaultMinter {
-
-        // Function that mints new tokens and deposits into an account's vault
-        // using their `Receiver` reference.
-        // We say `&AnyResource{Receiver}` to say that the recipient can be any resource
-        // as long as it implements the Receiver interface
-        pub fun mintTokens(amount: UFix64, recipient: &AnyResource{Receiver}) {
-                  FungibleToken.totalSupply = FungibleToken.totalSupply + UFix64(amount)
-            recipient.deposit(from: <-create Vault(balance: amount))
-        }
-    }
-
-    // The init function for the contract. All fields in the contract must
-    // be initialized at deployment. This is just an example of what
-    // an implementation could do in the init function. The numbers are arbitrary.
-    init() {
-        self.totalSupply = UFix64(30)
-
-        // create the Vault with the initial balance and put it in storage
-        // account.save saves an object to the specified `to` path
-        // The path is a literal path that consists of a domain and identifier
-        // The domain must be `storage`, `private`, or `public`
-        // the identifier can be any name
-        self.account.save(<-create Vault(balance: UFix64(30)), to: /storage/MainVault)
-
-        // Create a new VaultMinter resource and store it in account storage
-        self.account.save(<-create VaultMinter(), to: /storage/MainMinter)
+  post {
+    // Check that the capabilities were created correctly
+    // by getting the public capability and checking 
+    // that it points to a valid `Vault` object 
+    // that implements the `Receiver` interface
+    getAccount(0x01).getCapability(/public/MainReceiver)!
+                    .check<&FungibleToken.Vault{FungibleToken.Receiver}>():
+                    "Vault Receiver Reference was not created correctly"
     }
 }
 ```


### PR DESCRIPTION
## Description

I fixed a part of the fungible token tutorial document.
The code of `FungibleToken.cdc` was attached right after the word 'Transaction1.cdc should contain the following code'.
So I deleted the `FungibleToken.cdc` code and pasted the `Transaction1.cdc` code there.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
