### PR TITLE
Add addresses for other contracts to the docs

### DIFF
--- a/docs/content/token/staking/locked/transactions.mdx
+++ b/docs/content/token/staking/locked/transactions.mdx
@@ -21,6 +21,39 @@ sidebar_title: Transactions Reference
 
 # Contracts
 
+## `FlowToken`
+
+| Network | Contract Address     |
+|---------|----------------------|
+| Testnet | `0x7e60df042a9c0868` |
+| Mainnet | `0x1654653399040a61` |
+
+The `FlowToken` contract defines the FLOW network token.
+
+Source: [FlowToken.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowToken.cdc)
+
+## `FlowFees`
+
+The `FlowFees` contract is where all the collected flow fees are gathered.
+
+Source: [FlowFees.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowFees.cdc)
+
+| Network | Contract Address     |
+|---------|----------------------|
+| Testnet | `0x912d5440f7e3769e` |
+| Mainnet | `0xf919ee77447b7497` |
+
+## `FungibleToken`
+
+The `FungibleToken` contract implements the Fungible Token Standard. It is the second contract ever deployed on Flow.
+
+Source: [FungibleToken.cdc](https://github.com/onflow/flow-ft/blob/master/contracts/FungibleToken.cdc)
+
+| Network | Contract Address     |
+|---------|----------------------|
+| Testnet | `0x9a0766d93b6608b7` |
+| Mainnet | `0xf233dcee88fe0abe` |
+
 ## `LockedTokens`
 
 The `LockedTokens` contract defines the resources and interfaces 
@@ -33,6 +66,17 @@ Source: [LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/ma
 | Testnet | `0x95e019a17d0e23d7` |
 | Mainnet | `0x8d0e87b65159ae63` |
 
+## `FlowIDTableStaking`
+
+The `FlowIDTableStaking` contract is the Staking Contract that handles Staking, Delegating and Rewards
+
+Source: [FlowIDTableStaking.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc)
+
+| Network | Contract Address     |
+|---------|----------------------|
+| Testnet | `0x9eca2b38b18b5dfe` |
+| Mainnet | `0x8624b52f9ddcd04a` |
+
 ## `StakingProxy`
 
 The `StakingProxy` contract defines the interfaces through which **token holders** 
@@ -44,6 +88,7 @@ Source: [StakingProxy.cdc](https://github.com/onflow/flow-core-contracts/blob/ma
 |---------|----------------------|
 | Testnet | `0x7aad92e5a0715d21` |
 | Mainnet | `0x62430cf28c26d095` |
+
 
 # Transactions
 


### PR DESCRIPTION
But just those used in the core contracts transactions (so no NFT contract for example).

I've linked this page from the upcoming FAQ.