### PR TITLE
adds high level intro to staking

### DIFF
--- a/docs/content/token/staking/index.mdx
+++ b/docs/content/token/staking/index.mdx
@@ -1,380 +1,122 @@
 ---
-title: Staking Technical Overview
-description: How to use FLOW for staking and delegation
+title: Staking Introduction
+description: Introduction to how staking works on Flow
 ---
 
-<Callout type="warning">
-NOTE: The details of the transactions described in this document are for regular interaction with the staking smart contracts. 
-If you or your users have locked tokens from the FLOW token sale and want to stake them, 
-please see the locked tokens section of the documentation to learn the process for staking or delegation.
-</ Callout>
-
-<Callout type="warning">
-If you haven't read the Intro to Flow Staking document, please read that first. 
-That document provides a non-technical overview of staking on Flow for all users and is a necessary pre-requisite to this document.
-</ Callout>
-
-<Callout type="warning">
-This document assumes you have some technical knowledge about the Flow blockchain and programming environment.
-</ Callout>
-
-# Staking
-
-This document describes the functionality of the [core identity table and staking smart contract](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc).
-It gives an overview of the process of staking, epochs, and delegation. It is an important pre-requisite
-to understand before proceeding with any other technical integration or interaction with the Flow Protocol,
-but it is not step-by-step instructions for how to perform specific actions. 
-
-This document also describes how to read public staking data from the contract. 
-Anyone with a Flow account on mainnet can read public data from the staking smart contract with these instructions.
+# Overview
 
-The transactions described in this document are contained in the [`flow-core-contracts/transactions/idTableStaking/`](https://github.com/onflow/flow-core-contracts/tree/master/transactions/idTableStaking)
-directory. You can see the text of all the transactions used to interact with the smart contract there.
+This documents provides an introduction to staking, an important action that
+users of a proof of stake (PoS) blockchain need to be aware of to ensure the security
+of the network and receive token rewards.
 
-## Terminology
-
-If any of the definitions are confusing, you can find more detail in the contract docs below the terminology section.
+# What is Staking?
 
-**Staker:** Any user who has staked tokens for the Flow network. A node operator is a staker, and a delegator is a staker as well.
-
-**Node Operator:** A user who operates a node for the Flow network. Each node operator has a unique `NodeStaker` 
-object they store in their account to perform staking operations.
-
-**Delegator:** A user who delegates tokens to a node operator and receives rewards for their staked tokens, minus a fee
-taken by the node operator. Each delegator stores a unique `NodeDelegator` object in their account
-that allows them to perform staking operations.
+A blockchain is a global network of thousands of computers who work together
+to maintain the security and integrity of a shared state that millions of applications and people around the world use. 
+Every node operator has a small part of the responsibility to keep the network running smoothly 
+and to ensure that other node operators are doing the same. 
+This large distribution of resources makes it so that control never gets centralized in the control of one person or organization.
 
-**Identity Table:** The record of all the stakers in the network. 
-The identity table keeps separate lists for the info about node operators and delegators,
-which track the following info:
-
-- **Node Operators:**
-    * Node ID: 32 byte identifier for the node. Usually a hash of the node public key.
-    * Role: Indicates what role the node operator is. (Collection, Consensus, Execution, Verification, Access)
-    * Networking Address: The address that the node operator uses for networking.
-    * Networking Key: The node operator public key for networking.
-    * Staking Key: The public key for the account that manages staking.
-
-- **Delegators:**
-    * id: The ID associated with a delegator. These IDs are assigned to delegators automatically
-    by the staking contract and are only unique within an individual node operators' record.
-    * nodeID: The ID of the node operator a user delegates to.
-
-- **Both:**
-    * Tokens Committed: The tokens that a user has committed to stake in the next epoch.
-    * Tokens Staked: The tokens that a user has staked in the current epoch.
-    * Tokens Requested to Unstake: The amount of tokens that a user has requested to be unstaked
-      at the end of the current epoch.
-    * Tokens Unstaking: The tokens that were unstaked at the beginning of the current epoch and
-      are being held for an additional epoch holding period before being released.
-    * Tokens Unstaked: Tokens that used to be committed or staked and have been unstaked.
-    * Tokens Rewarded: Tokens that the user has received via staking rewards.
-
-**Epoch:** The period of time between reward payments and changes in the identity table. (Initially a week)
-At the end of every epoch, insufficiently staked node operators are refunded their stake,
-rewards are paid to those who are currently staked, committed tokens are marked as staked, 
-unstaking tokens are marked as unstaked, and unstaking requests are changed from staked to unstaking.
-
-**Delegation Rewards Cut:** The percentage of a delegator's rewards that the node operators take. Initially set to 8%.
-
-**Epoch Payout:** The total amount of tokens paid in rewards at the end of an epoch. 
-This value will change as the supply of FLOW changes. See the rewards page for more details.
-
-**Minimum Stake Requirement:** Each node type has a requirement for the minimum number of FLOW
-they have to commit to stake to be considered a valid node and receive rewards. If a node operator
-does not meet the minimum stake, they will not be included in the next epoch and will not receive any rewards.
-Delegators are not subject to minimum stake requirements.
-
-- Collector Nodes: 250,000 FLOW
-- Consensus Nodes: 500,000 FLOW
-- Execution Nodes: 1,250,000 FLOW
-- Verification Nodes: 135,000 FLOW
-
-## Smart Contract Summary
-
-The Flow staking smart contract manages a record of stakers who have staked tokens for the network. 
-Users who want to stake can register with the staking contract at any time, and their tokens will
-be locked for staking until they request to unstake them.
-
-Before getting into the details of the contract, we need to discuss how time in Flow is organized.
-The operation of the Flow network is divided into epochs, which are week-long periods where various
-network maintenance operatios are performed. The schedule of each epoch is exactly the same, though
-individual actions that users take in relation to staking with the network will be different.
-
-Epoch Schedule:
-
-1. **Start of Epoch:** Generic metadata about the current epoch is updated and shared.
-2. **Staking Auction:** Stakers can perform any action they want to manage their stake, like
-    initially registering, staking new tokens, unstaking tokens, or withdrawing rewards.
-    This phase takes up the vast majority of time in the epoch.
-3. **Remove Insufficiently Staked Nodes:** All node operators who don't meet the minimum will be removed.
-4. **Rewards Payout:** Pay rewards to all the node operators staked in the current epoch.
-5. **Move tokens between pools.** (See the token pools section for the order of movements)
+What is to stop these node operators from misbehaving and stealing someone else’s money 
+or modifying the state of the network in an unauthorized way? Staking! 
+Every node operator has to temporarily give (or ‘stake’) 
+a large number of their tokens to the network as a promise that they will behave. 
 
-The `FlowIDTableStaking` contract manages the identity table, and all of these phases. 
-Initially, control of these phases will be managed manually by the Flow Token Admin,
-but control will eventually be completely decentralized and managed by the node software, smart contracts,
-and democratically by all the stakers in the network.
 
-## Staking as a node operator
 
-To stake for a node, node operators first need to generate their staking key,
-networking address, and networking key.
-
-The [node operation guide](https://docs.onflow.org/docs/node-operation-consolidated-guide) 
-describes how to run a node and generate node information.
+This process is called staking. 
+If they ever misbehave, a number of their staked tokens will be taken from them as a punishment. 
+This incentivizes all the node operators to behave with the interests of all the users of the network in mind. 
+Every node watches other nodes and reports them if they misbehave. 
 
-To generate a node ID, simply hash the staking key.
 
-Node operators need to determine the role of node they will be running 
-(Collector, Consensus, Execution, Verification, or Access).
-
-<Callout type="warning">
-NOTE: Access Nodes are eligible to stake but will not receive rewards for their stake. 
-Please register as a different node type if you would like to receive rewards.
-</ Callout>
-
-Once the info has been determined:
-* Node role: `UInt8` (1 = Collector, 2 = Consensus, 3 = Execution, 4 = Verification, 5 = Access)
-* Node ID: 32 byte `String`
-* Networking Address: `String`
-* Networking Key: `String`
-* Staking Key: `String`
-
-The node operator is ready to submit a staking request.
 
-<Callout type="warning">
-NOTE: The staking smart contract does not validate that the strings for the address and keys are valid.
-It simply checks to make sure they are unique. The staking admin/node software will check to make sure 
-they are valid and if they are not, the registered node will not be eligible to stake.
-</ Callout>
+If nodes maintain the network well and never misbehave, the protocol pays them rewards on a regular basis!
 
-To create and submit a regular staking request, 
-the node operator submits a **Create Staking Request** transaction,
-providing all the node info, and the tokens that they want to stake.
 
-This registers the node in the Flow node identity table
-and commits the specified tokens to stake during the next epoch.
-This also stores a special node operator object in the node operator's account 
-that is used for staking, unstaking, and withdrawing rewards.
+# How does Staking work in Flow?
 
-Every node operator will run the same transaction to register their node at any time throughout an epoch.
-The register transaction only needs to be submitted once per node. 
-A registration cannot be used to manage multiple nodes. 
-Multiple nodes need to be registered separately.
+The Flow protocol maintains a list of node operators. 
+The list contains important information about each node, like their public keys, node address, and what kind of node they are running. 
+(Collection, Consensus, Execution, Verification, or Access)
 
-Once node operators have registered and have the special node object, they will be able
-to perform any of the valid staking options with it, assuming that they have
-the required amount of tokens to perform each operation.
+[Diagram of a ledger of node Identities]
 
-When a new epoch starts, if a staker has committed at least the minimum stake required,
-the tokens they have committed will be marked as staked and held in the protocol state.
-If a staker does not meet the minimum requirement, their committed tokens are 
-moved to their unstaked pool, which they can withdraw from at any time.
+To register as a node, the node operator submits a request to register their node along with tokens they want to stake.
 
-If a node operator has users delegating to them, they cannot withdraw their own tokens 
-such that their own staked tokens would fall below the minimum requirement for that node type.
-This is enforced at the protocol level. If they have delegators 
-and try to submit an unstaking transaction that would put their stake below the minimum, it will fail. 
+Once a node operator is registered and staked, assuming they keep their node online, are well behaved, 
+and are consistent maintainers of the network, they receive rewards at the end of every week. 
+This timeframe of earning rewards is otherwise known as an Epoch.
 
-If they want to unstake below the minimum, they must unstake all of their tokens,
-which also unstakes all of the tokens that have been delegated to them.
 
-Consequently, a node operator cannot accept delegation unless their own stake is above the minimum.
+# Epochs
 
-## Staking as a Delegator
+An epoch is a week-long period that the network uses to manage the stakers and pay rewards.
+Every epoch, a list of committed nodes are chosen to be the staked nodes of the network, 
+and their staked tokens are locked in and cannot change for the duration of the epoch. 
+At the end of the epoch, rewards are paid to each node based on how many tokens they had staked for that epoch. 
+This process repeats itself indefinitely, as long as the network remains functioning.
 
-Every staked node in the Flow network is eligible for delegation by any other user.
-The user only needs to know the node ID of the node they want to delegate to.
+[Diagram showing the list of node IDs changing every epoch, and rewards at the end of each epoch]
 
-To register as a delegator, the delegator submits the **Register Delegator**
-transaction, providing the id of the node operator they want to delegate to. 
-This transactions stores the `NodeDelegator` object
-in the user's account, which is what they use to perform staking operations.
+To determine the list of nodes that are included as officially staked nodes in the next epoch, 
+the protocol looks at the records of all the nodes that have committed tokens. 
+It checks to make sure each node’s information is correct and that the node is running properly. 
+Each node also has to have committed tokens above the minimum stake required for their node. 
+If any of these checks are insufficient, the node is not included in the next epoch. 
+If a node passes all the checks, they are approved and included as an official node for the next epoch.
 
-Users are able to get a list of possible node ids to delegate to via on-chain scripts.
-This information will also be provided off-chain, directly from the node operators or via
-third-party services. Flow is also planning on listing node IDs in a public place like Flow Port.
+[Diagram showing various node’s committed information, with some approved and some disapproved]
 
-The fee that node operators take from the rewards their delegators receive is 8%.
-A node operator cannot be delegated to unless the total tokens they have committed to stake
-are above the minimum requirement for their node types.
+Nodes do not have to continue to submit staking requests every epoch in order to remain staked. 
+As long as they continue to run their node properly, their tokens will remain staked. 
+A node operator only needs to take action if they want to stake more tokens or if they want to unstake their staked tokens. 
+If a node operator decides to stake or unstake tokens, 
+their requests are not carried out until the end of the current epoch.
+In the case of unstaking requests, they also must wait an additional epoch before their unstaked tokens are available to withdraw.
 
-The delegation logic keeps track of the amount of tokens each delegator has delegated for the node operator.
-When rewards are paid, the node operator takes the 8% cut of the delegator's rewards and the
-delegators rewards are deposited in the delegator's reward pool.
+[Diagram showing epoch schedule with staking and unstaking requests]
 
-## Staking Operations available to All Stakers
+# Rewards
 
-Regardless of whether they are a node operator or delegator, a staker has access
-to all the same staking operations.
+Please see the [Rewards](../rewards) section of the documentation for information about reward calculations and schedule.
 
-### Stake more Tokens
+# Delegation
+Any account in the network may also participate in staking by delegating their tokens to a node operator. 
+Every node operator in the network is eligible to receive delegation, there is no opting out. 
 
-A staker can commit more tokens to stake for the next epoch at any time,
-and there are three different ways to do it.
+To delegate to a node, a user simply specifies the ID of the node they want to delegate to 
+and the amount of tokens they want to delegate. 
+The tokens are committed and managed in the exact same way that normal staked tokens are managed. 
 
-1. They can commit new tokens to stake by submitting the **stake_new_tokens** transaction,
-which withdraws tokens from their account's flow token vault and commits them.
-2. They can commit tokens that are in their unstaked token pool, which holds the tokens
-that they have unstaked. Submit the **stake_unstaked_tokens**
-transaction to move the tokens from the unstaked pool to the committed pool.
-3. They can commit tokens that are in their rewarded token pool, which holds the tokens
-they have been awarded. They submit the **stake_rewarded_tokens**
-transaction to move the tokens from the rewards pool to the committed pool.
+Rewards for delegators are also calculated in the exact same way that rewards for node operators are calculated, 
+with one difference in that 8% of the calculated amount is given to the node operator being delegated to. 
+The remaining 92% is awarded to the delegator.
 
-### Unstake Tokens
+[Diagram of Delegation reward calculation]
 
-At anytime, a staker can also submit a request to unstake tokens with the **request_unstaking** transaction.
-This marks the specified amount of tokens to be unstaked at the end of the epoch.
-At the end of the epoch, their tokens are moved to the unstaking pool.
-They will sit in this pool for one (1) additional epoch,
-at which point they will be moved to the unstaked tokens pool.
+# How Do I Stake?
 
-### Withdraw Unstaked Tokens
-At any time, stakers are able to be freely withdraw from their unstaked tokens pool
-with the **withdraw_unstaked** transaction.
+So you have decided you want to be a part of the Flow Protocol. Welcome! 
+You are joining a group of people from all around the world that are a part of a movement centered 
+around bringing decentralization and transparency into the world. 
 
-### Withdraw Rewarded Tokens
+## Developers
 
-Staking rewards are paid at the end of every epoch based on how many tokens
-are in a users `tokensStaked` pool. Every staker's rewards
-are deposited to their rewarded tokens pool. Rewards can be withdrawn
-at any time by submitting the **withdraw_reward_tokens** transaction.
-
-These tokens are unlocked and can be transferred on-chain if desired, or re-staked.
-
-**See the [transactions document](../transactions) for more detail about each transaction stakers can use to participate.**
-
-# Appendix
-
-## Token Pools
-
-Each node operator has five token pools allocated to them:
-
-- **Committed Tokens:** Tokens that are committed for the next epoch. 
-They are automatically moved to the staked pool when the next epoch starts.
-- **Staked Tokens:** Tokens that are staked by the node operator for the current epoch.
-They are only moved at the end of an epoch and if the staker 
-has submitted an unstaking request.
-- **Unstaking Tokens:** Tokens that have been unstaked,
-but are not free to withdraw until the following epoch. 
-- **Unstaked Tokens:** Tokens that are freely available to withdraw or re-stake.
-Unstaked tokens go to this pool.
-- **Rewarded Tokens:** Tokens that are freely available to withdraw or re-stake. 
-Rewards are paid and deposited to the rewarded Pool after each epoch.
-
-At the end of every epoch, tokens are moved between pools in this order:
-
-1. All Committed Tokens will get moved either to the Staked Tokens pool, 
-or to the Unstaked Tokens pool (depending on if the staked request has met the minimum stake requirements).
-2. All Committed Tokens get moved to staked Tokens pool.
-3. All unstaking tokens get moved to the unstaked tokens pool.
-4. All requested unstaking tokens get moved from the staked pool to the unstaking pool.
-
-
-## Reading Info from the Staking Contract
-
-There are various ways to retreive information about the current state of the staking contract.
-
-### Getting the list of proposed nodes for the next epoch:
-
-`FlowIDTableStaking.getProposedNodeIDs()`: Returns an array of node IDs for proposed nodes. 
-Proposed nodes are nodes that have enough staked and committed for the next epoch to be above the minimum requirement.
-
-You can use the **Get Proposed Table**([SC.05](../transactions/#getting-staking-info))  script for retreiving this info.
-
-This script requires no arguments.
-
-### Get the list of all nodes that are currently staked:
-
-`FlowIDTableStaking.getStakedNodeIDs()`: Returns an array of nodeIDs that are currently staked.
-Staked nodes are nodes that currently have staked tokens above the minimum.
-
-You can use the **Get Current Table**([SC.04](../transactions/#getting-staking-info)) script for retreiving this info.
-
-This script requires no arguments.
-
-### Get all of the info associated with a single node staker:
-
-`FlowIDTableStaking.NodeInfo(nodeID: String)`: Returns a `NodeInfo` struct with all of the metadata
-associated with the specified node ID. You can see the `NodeInfo` definition in the [FlowIDTableStaking
-smart contract.](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc#L264)
-
-You can use the **Get Node Info**([SC.08](../transactions/#getting-staking-info)) script 
-with the following arguments:
-
-| Argument   | Type     | Description |
-|------------|----------|-------------|
-| **nodeID** | `String` | The node ID of the node to search for. |
-
-### Get the total committed balance of a node:
-
-`FlowIDTableStaking.getTotalCommittedBalance(_ nodeID: String)`: Returns the total committed balance for a node,
-which is their total tokens staked + committed, plus all of the staked + committed tokens of all their delegators.
-
-You can use the **Get Node Total Commitment**([SC.09](../transactions/#getting-staking-info)) script 
-with the following argument:
-
-| Argument   | Type     | Description |
-|------------|----------|-------------|
-| **nodeID** | `String` | The node ID of the node to search for. |
-
-
-### Get all the info associated with a single delegator:
-
-`FlowIDTableStaking.DelegatorInfo(nodeID: String, delegatorID: UInt32)`: Returns a `DelegatorInfo` struct with all of the metadata
-associated with the specified node ID and delegator ID. You can see the `NodeInfo` definition in the [FlowIDTableStaking
-smart contract.](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc#L348)
-
-You can use the **Get Delegator Info**([SC.10](../transactions/#getting-staking-info)) 
-script with the following arguments:
-
-| Argument   | Type     | Description |
-|------------|----------|-------------|
-| **nodeID** | `String` | The node ID that the delegator delegates to. |
-| **delegatorID** | `String` | The ID of the delegator to search for. |
-
-### Get the delegation cut percentage:
-
-`FlowIDTableStaking.getRewardCutPercentage(): UFix64`: Returns a `UFix64` number for the cut of delegator rewards that each node operator takes.
-
-You can use the **Get Cut Percentage**([SC.01](../transactions/#getting-staking-info)) script to retreive this info.
-
-This script requires no arguments.
-
-## Get the Minimum Stake Requirements:
-
-`FlowIDTableStaking.getMinimumStakeRequirements(): {UInt8: UFix64}`: Returns a mapping
-for the stake requirements for each node type.
-
-You can use the **Get stake requirements**([SC.02](../transactions/#getting-staking-info)) script to retreive this info.
-
-This script requires no arguments.
-
-### Get the Total Weekly Reward Payout:
-
-`FlowIDTableStaking.getEpochTokenPayout(): UFix64`: Returns a `UFix64` value for the total number of FLOW paid out each epoch (week).
-
-You can use the **Get weekly payout**([SC.03](../transactions/#getting-staking-info)) script to retreive this info.
-
-This script requires no arguments.
-
-### Get the Total FLOW Staked:
-
-You can use the **Get total FLOW staked**([SC.06](../transactions/#getting-staking-info)) script to retreive this info.
-
-This script requires no arguments.
-
-### Get the Total FLOW Staked by a single node type:
-
-You can use the **Get total FLOW staked by node type**([SC.07](../transactions/#getting-staking-info)) script
-with the following arguments:
-
-| Argument   | Type     | Description |
-|------------|----------|-------------|
-| **nodeType** | `UInt8` | The type of node to search for. |
-
-
-The source code for the staking contract and more transactions 
-can be found in the [Flow Core Contracts Github Repository](https://github.com/onflow/flow-core-contracts/tree/josh/staking).
+If you are a developer or other technically-minded person and want to learn more detail
+about the inner workings of the identity table and staking protocol, please see the staking technical documentation.
+
+## Staking via a Custody Provider
+
+If you are using a custody provider who controls your account and private keys for you, 
+such as Kraken, Finoa, or Coinlist, they all have different policies and processes 
+for what you need to do to stake your tokens, the rewards you receive, 
+and the fees that they take from your staking rewards. 
+Please reach out to them if you have any questions about staking your tokens with your provider.
+
+## Manual Staking
+
+If you are self-custodying your account and keys, you will need to learn more about how staking works
+and how you can participate safely and reliably. 
+See the manual staking documentation for information about how you can use your FLOW 
+to stake with the network via Flow Port.

--- a/docs/content/token/staking/technical.mdx
+++ b/docs/content/token/staking/technical.mdx
@@ -1,0 +1,380 @@
+---
+title: Staking Technical Overview
+description: How to use FLOW for staking and delegation
+---
+
+<Callout type="warning">
+NOTE: The details of the transactions described in this document are for regular interaction with the staking smart contracts. 
+If you or your users have locked tokens from the FLOW token sale and want to stake them, 
+please see the locked tokens section of the documentation to learn the process for staking or delegation.
+</ Callout>
+
+<Callout type="warning">
+If you haven't read the Intro to Flow Staking document, please read that first. 
+That document provides a non-technical overview of staking on Flow for all users and is a necessary pre-requisite to this document.
+</ Callout>
+
+<Callout type="warning">
+This document assumes you have some technical knowledge about the Flow blockchain and programming environment.
+</ Callout>
+
+# Staking
+
+This document describes the functionality of the [core identity table and staking smart contract](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc).
+It gives an overview of the process of staking, epochs, and delegation. It is an important pre-requisite
+to understand before proceeding with any other technical integration or interaction with the Flow Protocol,
+but it is not step-by-step instructions for how to perform specific actions. 
+
+This document also describes how to read public staking data from the contract. 
+Anyone with a Flow account on mainnet can read public data from the staking smart contract with these instructions.
+
+The transactions described in this document are contained in the [`flow-core-contracts/transactions/idTableStaking/`](https://github.com/onflow/flow-core-contracts/tree/master/transactions/idTableStaking)
+directory. You can see the text of all the transactions used to interact with the smart contract there.
+
+## Terminology
+
+If any of the definitions are confusing, you can find more detail in the contract docs below the terminology section.
+
+**Staker:** Any user who has staked tokens for the Flow network. A node operator is a staker, and a delegator is a staker as well.
+
+**Node Operator:** A user who operates a node for the Flow network. Each node operator has a unique `NodeStaker` 
+object they store in their account to perform staking operations.
+
+**Delegator:** A user who delegates tokens to a node operator and receives rewards for their staked tokens, minus a fee
+taken by the node operator. Each delegator stores a unique `NodeDelegator` object in their account
+that allows them to perform staking operations.
+
+**Identity Table:** The record of all the stakers in the network. 
+The identity table keeps separate lists for the info about node operators and delegators,
+which track the following info:
+
+- **Node Operators:**
+    * Node ID: 32 byte identifier for the node. Usually a hash of the node public key.
+    * Role: Indicates what role the node operator is. (Collection, Consensus, Execution, Verification, Access)
+    * Networking Address: The address that the node operator uses for networking.
+    * Networking Key: The node operator public key for networking.
+    * Staking Key: The public key for the account that manages staking.
+
+- **Delegators:**
+    * id: The ID associated with a delegator. These IDs are assigned to delegators automatically
+    by the staking contract and are only unique within an individual node operators' record.
+    * nodeID: The ID of the node operator a user delegates to.
+
+- **Both:**
+    * Tokens Committed: The tokens that a user has committed to stake in the next epoch.
+    * Tokens Staked: The tokens that a user has staked in the current epoch.
+    * Tokens Requested to Unstake: The amount of tokens that a user has requested to be unstaked
+      at the end of the current epoch.
+    * Tokens Unstaking: The tokens that were unstaked at the beginning of the current epoch and
+      are being held for an additional epoch holding period before being released.
+    * Tokens Unstaked: Tokens that used to be committed or staked and have been unstaked.
+    * Tokens Rewarded: Tokens that the user has received via staking rewards.
+
+**Epoch:** The period of time between reward payments and changes in the identity table. (Initially a week)
+At the end of every epoch, insufficiently staked node operators are refunded their stake,
+rewards are paid to those who are currently staked, committed tokens are marked as staked, 
+unstaking tokens are marked as unstaked, and unstaking requests are changed from staked to unstaking.
+
+**Delegation Rewards Cut:** The percentage of a delegator's rewards that the node operators take. Initially set to 8%.
+
+**Epoch Payout:** The total amount of tokens paid in rewards at the end of an epoch. 
+This value will change as the supply of FLOW changes. See the rewards page for more details.
+
+**Minimum Stake Requirement:** Each node type has a requirement for the minimum number of FLOW
+they have to commit to stake to be considered a valid node and receive rewards. If a node operator
+does not meet the minimum stake, they will not be included in the next epoch and will not receive any rewards.
+Delegators are not subject to minimum stake requirements.
+
+- Collector Nodes: 250,000 FLOW
+- Consensus Nodes: 500,000 FLOW
+- Execution Nodes: 1,250,000 FLOW
+- Verification Nodes: 135,000 FLOW
+
+## Smart Contract Summary
+
+The Flow staking smart contract manages a record of stakers who have staked tokens for the network. 
+Users who want to stake can register with the staking contract at any time, and their tokens will
+be locked for staking until they request to unstake them.
+
+Before getting into the details of the contract, we need to discuss how time in Flow is organized.
+The operation of the Flow network is divided into epochs, which are week-long periods where various
+network maintenance operatios are performed. The schedule of each epoch is exactly the same, though
+individual actions that users take in relation to staking with the network will be different.
+
+Epoch Schedule:
+
+1. **Start of Epoch:** Generic metadata about the current epoch is updated and shared.
+2. **Staking Auction:** Stakers can perform any action they want to manage their stake, like
+    initially registering, staking new tokens, unstaking tokens, or withdrawing rewards.
+    This phase takes up the vast majority of time in the epoch.
+3. **Remove Insufficiently Staked Nodes:** All node operators who don't meet the minimum will be removed.
+4. **Rewards Payout:** Pay rewards to all the node operators staked in the current epoch.
+5. **Move tokens between pools.** (See the token pools section for the order of movements)
+
+The `FlowIDTableStaking` contract manages the identity table, and all of these phases. 
+Initially, control of these phases will be managed manually by the Flow Token Admin,
+but control will eventually be completely decentralized and managed by the node software, smart contracts,
+and democratically by all the stakers in the network.
+
+## Staking as a node operator
+
+To stake for a node, node operators first need to generate their staking key,
+networking address, and networking key.
+
+The [node operation guide](https://docs.onflow.org/docs/node-operation-consolidated-guide) 
+describes how to run a node and generate node information.
+
+To generate a node ID, simply hash the staking key.
+
+Node operators need to determine the role of node they will be running 
+(Collector, Consensus, Execution, Verification, or Access).
+
+<Callout type="warning">
+NOTE: Access Nodes are eligible to stake but will not receive rewards for their stake. 
+Please register as a different node type if you would like to receive rewards.
+</ Callout>
+
+Once the info has been determined:
+* Node role: `UInt8` (1 = Collector, 2 = Consensus, 3 = Execution, 4 = Verification, 5 = Access)
+* Node ID: 32 byte `String`
+* Networking Address: `String`
+* Networking Key: `String`
+* Staking Key: `String`
+
+The node operator is ready to submit a staking request.
+
+<Callout type="warning">
+NOTE: The staking smart contract does not validate that the strings for the address and keys are valid.
+It simply checks to make sure they are unique. The staking admin/node software will check to make sure 
+they are valid and if they are not, the registered node will not be eligible to stake.
+</ Callout>
+
+To create and submit a regular staking request, 
+the node operator submits a **Create Staking Request** transaction,
+providing all the node info, and the tokens that they want to stake.
+
+This registers the node in the Flow node identity table
+and commits the specified tokens to stake during the next epoch.
+This also stores a special node operator object in the node operator's account 
+that is used for staking, unstaking, and withdrawing rewards.
+
+Every node operator will run the same transaction to register their node at any time throughout an epoch.
+The register transaction only needs to be submitted once per node. 
+A registration cannot be used to manage multiple nodes. 
+Multiple nodes need to be registered separately.
+
+Once node operators have registered and have the special node object, they will be able
+to perform any of the valid staking options with it, assuming that they have
+the required amount of tokens to perform each operation.
+
+When a new epoch starts, if a staker has committed at least the minimum stake required,
+the tokens they have committed will be marked as staked and held in the protocol state.
+If a staker does not meet the minimum requirement, their committed tokens are 
+moved to their unstaked pool, which they can withdraw from at any time.
+
+If a node operator has users delegating to them, they cannot withdraw their own tokens 
+such that their own staked tokens would fall below the minimum requirement for that node type.
+This is enforced at the protocol level. If they have delegators 
+and try to submit an unstaking transaction that would put their stake below the minimum, it will fail. 
+
+If they want to unstake below the minimum, they must unstake all of their tokens,
+which also unstakes all of the tokens that have been delegated to them.
+
+Consequently, a node operator cannot accept delegation unless their own stake is above the minimum.
+
+## Staking as a Delegator
+
+Every staked node in the Flow network is eligible for delegation by any other user.
+The user only needs to know the node ID of the node they want to delegate to.
+
+To register as a delegator, the delegator submits the **Register Delegator**
+transaction, providing the id of the node operator they want to delegate to. 
+This transactions stores the `NodeDelegator` object
+in the user's account, which is what they use to perform staking operations.
+
+Users are able to get a list of possible node ids to delegate to via on-chain scripts.
+This information will also be provided off-chain, directly from the node operators or via
+third-party services. Flow is also planning on listing node IDs in a public place like Flow Port.
+
+The fee that node operators take from the rewards their delegators receive is 8%.
+A node operator cannot be delegated to unless the total tokens they have committed to stake
+are above the minimum requirement for their node types.
+
+The delegation logic keeps track of the amount of tokens each delegator has delegated for the node operator.
+When rewards are paid, the node operator takes the 8% cut of the delegator's rewards and the
+delegators rewards are deposited in the delegator's reward pool.
+
+## Staking Operations available to All Stakers
+
+Regardless of whether they are a node operator or delegator, a staker has access
+to all the same staking operations.
+
+### Stake more Tokens
+
+A staker can commit more tokens to stake for the next epoch at any time,
+and there are three different ways to do it.
+
+1. They can commit new tokens to stake by submitting the **stake_new_tokens** transaction,
+which withdraws tokens from their account's flow token vault and commits them.
+2. They can commit tokens that are in their unstaked token pool, which holds the tokens
+that they have unstaked. Submit the **stake_unstaked_tokens**
+transaction to move the tokens from the unstaked pool to the committed pool.
+3. They can commit tokens that are in their rewarded token pool, which holds the tokens
+they have been awarded. They submit the **stake_rewarded_tokens**
+transaction to move the tokens from the rewards pool to the committed pool.
+
+### Unstake Tokens
+
+At anytime, a staker can also submit a request to unstake tokens with the **request_unstaking** transaction.
+This marks the specified amount of tokens to be unstaked at the end of the epoch.
+At the end of the epoch, their tokens are moved to the unstaking pool.
+They will sit in this pool for one (1) additional epoch,
+at which point they will be moved to the unstaked tokens pool.
+
+### Withdraw Unstaked Tokens
+At any time, stakers are able to be freely withdraw from their unstaked tokens pool
+with the **withdraw_unstaked** transaction.
+
+### Withdraw Rewarded Tokens
+
+Staking rewards are paid at the end of every epoch based on how many tokens
+are in a users `tokensStaked` pool. Every staker's rewards
+are deposited to their rewarded tokens pool. Rewards can be withdrawn
+at any time by submitting the **withdraw_reward_tokens** transaction.
+
+These tokens are unlocked and can be transferred on-chain if desired, or re-staked.
+
+**See the [transactions document](../transactions) for more detail about each transaction stakers can use to participate.**
+
+# Appendix
+
+## Token Pools
+
+Each node operator has five token pools allocated to them:
+
+- **Committed Tokens:** Tokens that are committed for the next epoch. 
+They are automatically moved to the staked pool when the next epoch starts.
+- **Staked Tokens:** Tokens that are staked by the node operator for the current epoch.
+They are only moved at the end of an epoch and if the staker 
+has submitted an unstaking request.
+- **Unstaking Tokens:** Tokens that have been unstaked,
+but are not free to withdraw until the following epoch. 
+- **Unstaked Tokens:** Tokens that are freely available to withdraw or re-stake.
+Unstaked tokens go to this pool.
+- **Rewarded Tokens:** Tokens that are freely available to withdraw or re-stake. 
+Rewards are paid and deposited to the rewarded Pool after each epoch.
+
+At the end of every epoch, tokens are moved between pools in this order:
+
+1. All Committed Tokens will get moved either to the Staked Tokens pool, 
+or to the Unstaked Tokens pool (depending on if the staked request has met the minimum stake requirements).
+2. All Committed Tokens get moved to staked Tokens pool.
+3. All unstaking tokens get moved to the unstaked tokens pool.
+4. All requested unstaking tokens get moved from the staked pool to the unstaking pool.
+
+
+## Reading Info from the Staking Contract
+
+There are various ways to retreive information about the current state of the staking contract.
+
+### Getting the list of proposed nodes for the next epoch:
+
+`FlowIDTableStaking.getProposedNodeIDs()`: Returns an array of node IDs for proposed nodes. 
+Proposed nodes are nodes that have enough staked and committed for the next epoch to be above the minimum requirement.
+
+You can use the **Get Proposed Table**([SC.05](../transactions/#getting-staking-info))  script for retreiving this info.
+
+This script requires no arguments.
+
+### Get the list of all nodes that are currently staked:
+
+`FlowIDTableStaking.getStakedNodeIDs()`: Returns an array of nodeIDs that are currently staked.
+Staked nodes are nodes that currently have staked tokens above the minimum.
+
+You can use the **Get Current Table**([SC.04](../transactions/#getting-staking-info)) script for retreiving this info.
+
+This script requires no arguments.
+
+### Get all of the info associated with a single node staker:
+
+`FlowIDTableStaking.NodeInfo(nodeID: String)`: Returns a `NodeInfo` struct with all of the metadata
+associated with the specified node ID. You can see the `NodeInfo` definition in the [FlowIDTableStaking
+smart contract.](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc#L264)
+
+You can use the **Get Node Info**([SC.08](../transactions/#getting-staking-info)) script 
+with the following arguments:
+
+| Argument   | Type     | Description |
+|------------|----------|-------------|
+| **nodeID** | `String` | The node ID of the node to search for. |
+
+### Get the total committed balance of a node:
+
+`FlowIDTableStaking.getTotalCommittedBalance(_ nodeID: String)`: Returns the total committed balance for a node,
+which is their total tokens staked + committed, plus all of the staked + committed tokens of all their delegators.
+
+You can use the **Get Node Total Commitment**([SC.09](../transactions/#getting-staking-info)) script 
+with the following argument:
+
+| Argument   | Type     | Description |
+|------------|----------|-------------|
+| **nodeID** | `String` | The node ID of the node to search for. |
+
+
+### Get all the info associated with a single delegator:
+
+`FlowIDTableStaking.DelegatorInfo(nodeID: String, delegatorID: UInt32)`: Returns a `DelegatorInfo` struct with all of the metadata
+associated with the specified node ID and delegator ID. You can see the `NodeInfo` definition in the [FlowIDTableStaking
+smart contract.](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc#L348)
+
+You can use the **Get Delegator Info**([SC.10](../transactions/#getting-staking-info)) 
+script with the following arguments:
+
+| Argument   | Type     | Description |
+|------------|----------|-------------|
+| **nodeID** | `String` | The node ID that the delegator delegates to. |
+| **delegatorID** | `String` | The ID of the delegator to search for. |
+
+### Get the delegation cut percentage:
+
+`FlowIDTableStaking.getRewardCutPercentage(): UFix64`: Returns a `UFix64` number for the cut of delegator rewards that each node operator takes.
+
+You can use the **Get Cut Percentage**([SC.01](../transactions/#getting-staking-info)) script to retreive this info.
+
+This script requires no arguments.
+
+## Get the Minimum Stake Requirements:
+
+`FlowIDTableStaking.getMinimumStakeRequirements(): {UInt8: UFix64}`: Returns a mapping
+for the stake requirements for each node type.
+
+You can use the **Get stake requirements**([SC.02](../transactions/#getting-staking-info)) script to retreive this info.
+
+This script requires no arguments.
+
+### Get the Total Weekly Reward Payout:
+
+`FlowIDTableStaking.getEpochTokenPayout(): UFix64`: Returns a `UFix64` value for the total number of FLOW paid out each epoch (week).
+
+You can use the **Get weekly payout**([SC.03](../transactions/#getting-staking-info)) script to retreive this info.
+
+This script requires no arguments.
+
+### Get the Total FLOW Staked:
+
+You can use the **Get total FLOW staked**([SC.06](../transactions/#getting-staking-info)) script to retreive this info.
+
+This script requires no arguments.
+
+### Get the Total FLOW Staked by a single node type:
+
+You can use the **Get total FLOW staked by node type**([SC.07](../transactions/#getting-staking-info)) script
+with the following arguments:
+
+| Argument   | Type     | Description |
+|------------|----------|-------------|
+| **nodeType** | `UInt8` | The type of node to search for. |
+
+
+The source code for the staking contract and more transactions 
+can be found in the [Flow Core Contracts Github Repository](https://github.com/onflow/flow-core-contracts/tree/josh/staking).

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -256,6 +256,7 @@ const sections = [
       ],
       Staking: [
         "token/staking/index",
+        "token/staking/technical",
         "token/staking/rewards",
         "token/staking/stake-slashing",
         "token/staking/transactions",


### PR DESCRIPTION
Closes: https://github.com/dapperlabs/flow-go/issues/4989

## Description

* Changed the index page to have the high level intro to staking
* moved the smart contract technical overview to a `technical` document

There are a few placeholders for diagrams that I am working on. I might get rid of them if we want to merge this before the diagrams are ready