### PR TITLE
Update Flow Go SDK before updating Flow Go

### DIFF
--- a/docs/development/cadence-downstream-dependencies.md
+++ b/docs/development/cadence-downstream-dependencies.md
@@ -1,20 +1,20 @@
 # Updating the Cadence Downstream Dependencies / Releasing the CLI
 
 Updating the Cadence downstream dependencies should be done in the following steps:
-
-1. Update [Flow Go](https://github.com/onflow/flow-go):
+     
+1. Update [Flow Go SDK](https://github.com/onflow/flow-go-sdk):
    - Update to the latest Cadence version by running the following command (replace `X.X.X` with the version number):
      ```sh
      $ go get github.com/onflow/cadence@vX.X.X 
      ```
-     
-     - In the root directory
-     - In the `integration` directory
-     
-2. Update [Flow Go SDK](https://github.com/onflow/flow-go-sdk):
-   - Update `github.com/onflow/cadence` to the new release
    - Tag a new release and push it
    
+2. Update [Flow Go](https://github.com/onflow/flow-go):
+     - Update `github.com/onflow/cadence` to the new release
+     - Update `github.com/onflow/flow-go-sdk` to the new release
+     - In the root directory
+     - In the `integration` directory
+
 3. Update the [Flow Emulator](https://github.com/onflow/flow-emulator):
    - Update `github.com/onflow/flow-go` to the latest commit
    - Update `github.com/onflow/flow-go-sdk` to the new release


### PR DESCRIPTION
Flow Go depends on Flow Go SDK, so update it first