### PR TITLE
Docs for re-register, and node+delegator

### DIFF
--- a/docs/content/staking/locked-delegation-guide.mdx
+++ b/docs/content/staking/locked-delegation-guide.mdx
@@ -38,6 +38,10 @@ Once an account has registered as a delegator with one node, they cannot registe
 For more information, see [Delegate to Multiple Nodes from the Same Account](#delegate-to-multiple-nodes-from-the-same-account) below.
 This feature will be added in the future.
 
+An account can use this transaction to register a different delegator that replaces the old delegator, but only if they have withdrawn
+ALL tokens for their old delegator from their record in the staking contract. If there are any tokens remaining,
+the re-registration will fail. This is because the registration overwrites the old one, which would revoke access to the tokens.
+
 # Delegation Actions
 
 ## Delegate New Tokens
@@ -146,3 +150,8 @@ If a token holder wants to create a second delegation relationship, they must cr
 and transfer their locked tokens to the new account by requesting authorization from the token admin.
 
 We plan on adding functionality in the future to allow accounts to delegate to multiple nodes.
+
+## Stake from the Same Account
+
+An account who registers a delegator with locked tokens can also register a delegator in the same account. 
+See the Locked Staking Guide for how to register a node.

--- a/docs/content/staking/locked-delegation-guide.mdx
+++ b/docs/content/staking/locked-delegation-guide.mdx
@@ -153,5 +153,5 @@ We plan on adding functionality in the future to allow accounts to delegate to m
 
 ## Stake from the Same Account
 
-An account who registers a delegator with locked tokens can also register a delegator in the same account. 
-See the Locked Staking Guide for how to register a node.
+An account that registers as a delegator with locked FLOW can also register as a staked node in the same account. 
+See the [Locked Staking Guide](../locked-staking-guide) for how to register a node.

--- a/docs/content/staking/locked-staking-guide.mdx
+++ b/docs/content/staking/locked-staking-guide.mdx
@@ -38,7 +38,7 @@ This transaction registers the account as a staker with the specified node infor
 and attaches a `NodeStakerProxy` capability to the `TokenHolder` resource. 
 This capability can later be used to perform staking actions.
 
-Once an account has registered as a staker with one node, they cannot register any additional. 
+Once an account has registered as a staker with one node, they cannot register any additional nodes. 
 For more information, see [Stake Multiple Nodes from the Same Account](#stake-multiple-nodes-from-the-same-account) below.
 This feature will be added in the future.
 
@@ -166,5 +166,5 @@ We plan on adding functionality in the future to allow accounts to stake to mult
 
 ## Delegate from the Same Account
 
-An account who registers a node with locked tokens can also register a delegator in the same account. 
-See the Locked Delegation Guide for how to register a delegator.
+An account that registers a node with locked FLOW can also register as a delegator from the same account. 
+See the [Locked Delegation Guide](../locked-delegation-guide) for how to register a delegator.

--- a/docs/content/staking/locked-staking-guide.mdx
+++ b/docs/content/staking/locked-staking-guide.mdx
@@ -38,9 +38,13 @@ This transaction registers the account as a staker with the specified node infor
 and attaches a `NodeStakerProxy` capability to the `TokenHolder` resource. 
 This capability can later be used to perform staking actions.
 
-Once an account has registered as a staker with one node, they cannot register with any others. 
+Once an account has registered as a staker with one node, they cannot register any additional. 
 For more information, see [Stake Multiple Nodes from the Same Account](#stake-multiple-nodes-from-the-same-account) below.
 This feature will be added in the future.
+
+An account can use this transaction to register a different node that replaces the old node, but only if they have withdrawn
+ALL tokens for their node from their record in the staking contract. If there are any tokens remaining,
+the re-registration will fail. This is because the registration overwrites the old one, which would revoke access to their tokens.
 
 # Staking Actions
 
@@ -159,3 +163,8 @@ If a token holder wants to create a second staking relationship, they must creat
 and transfer their locked tokens to the new account by requesting authorization from the token admin.
 
 We plan on adding functionality in the future to allow accounts to stake to multiple nodes.
+
+## Delegate from the Same Account
+
+An account who registers a node with locked tokens can also register a delegator in the same account. 
+See the Locked Delegation Guide for how to register a delegator.

--- a/docs/content/staking/technical-overview.mdx
+++ b/docs/content/staking/technical-overview.mdx
@@ -72,6 +72,13 @@ which track the following info:
     * Tokens Unstaked: Tokens that used to be committed or staked and have been unstaked.
     * Tokens Rewarded: Tokens that the user has received via staking rewards.
 
+<Callout type="warning">
+NOTE: The staking smart contract does not associate a node or delegator with an account address.
+It associates it with the assigned resource object that corresponds to that entry in the contract.
+There can be any number of these objects stored in the same account, and they can be moved to different accounts
+if the owner chooses.
+</Callout> 
+
 **Epoch:** The period of time between reward payments and changes in the identity table. (Initially a week)
 At the end of every epoch, insufficiently staked node operators are refunded their stake,
 rewards are paid to those who are currently staked, committed tokens are marked as staked, 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-core-contracts/issues/73

## Description

Adds clarification that a node or delegator can re-register a different one, but only if they have withdrawn ALL their tokens beforehand.

Also adds section in each section saying that there can be a node and delegator for the same account.

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
