### PR TITLE
Fix links for core contracts docs page.

### DIFF
--- a/docs/content/protocol/core-contracts/index.md
+++ b/docs/content/protocol/core-contracts/index.md
@@ -9,7 +9,7 @@ Flow protocol.
 These contracts control the following:
 
 - Standard fungible token behavior
-- Default token behavior ([FlowToken](../flow-token)) 
+- Default token behavior ([FlowToken](./flow-token))
 - Account, transaction and storage fee payments
-- Staking and delegation ([FlowIDTableStaking](../flow-id-table-staking))
-- Token lock-ups ([LockedTokens](../locked-tokens))
+- Staking and delegation ([FlowIDTableStaking](./flow-id-table-staking))
+- Token lock-ups ([LockedTokens](./locked-tokens))


### PR DESCRIPTION
The links in the body of https://docs.onflow.org/protocol/core-contracts/ were reported broken by a community member on Discord.

This fixes the links. 