### PR TITLE
Replace Discord link with Discourse. Add home links.

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -101,7 +101,8 @@ const sections = [
     patterns: ["tutorial/cadence/*", "guides/cadence/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
-      null: [
+      null: ["[Home](/)"],
+      Overview: [
         "tutorial/cadence/00-introduction",
         "[Cadence Language Reference](/cadence/language)",
       ],
@@ -126,8 +127,9 @@ const sections = [
     patterns: ["sdks/golang/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
-      null: ["sdks/golang/index", "sdks/golang/changelog"],
-      "How To": [
+      null: ["[Home](/)"],
+      Overview: ["sdks/golang/index", "sdks/golang/changelog"],
+      "Developer Guides": [
         "sdks/golang/create-account",
         "sdks/golang/build-transaction",
         "sdks/golang/sign-transaction",
@@ -142,7 +144,11 @@ const sections = [
     sourceInstanceName: "docs",
     patterns: ["sdks/javascript/**/*"],
     sidebar: {
-      null: ["sdks/javascript/index", "sdks/javascript/create-account"],
+      null: ["[Home](/)"],
+      "Developer Guides": [
+        "sdks/javascript/index",
+        "sdks/javascript/create-account",
+      ],
     },
   },
   {
@@ -150,6 +156,7 @@ const sections = [
     patterns: ["concepts/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
+      null: ["[Home](/)"],
       Accounts: ["concepts/accounts-and-keys", "concepts/transaction-signing"],
     },
   },
@@ -158,7 +165,7 @@ const sections = [
     patterns: ["protocol/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
-      null: ["protocol/access-api"],
+      null: ["[Home](/)"],
       "Core Contracts": [
         "protocol/core-contracts/fungible-token",
         "protocol/core-contracts/flow-token",
@@ -166,6 +173,7 @@ const sections = [
         "protocol/core-contracts/flow-id-table-staking",
         "protocol/core-contracts/locked-tokens",
       ],
+      "Developer Guides": ["protocol/access-api"],
     },
   },
   {
@@ -173,6 +181,7 @@ const sections = [
     patterns: ["token/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
+      null: ["[Home](/)"],
       Overview: [
         "token/index",
         "token/earn",
@@ -188,7 +197,13 @@ const sections = [
     patterns: ["staking/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
-      Overview: ["staking/index", "staking/rewards", "staking/stake-slashing", "staking/faq"],
+      null: ["[Home](/)"],
+      Overview: [
+        "staking/index",
+        "staking/rewards",
+        "staking/stake-slashing",
+        "staking/faq",
+      ],
       "Developer Guides": [
         "staking/technical-overview",
         "staking/locked-delegation-guide",
@@ -203,6 +218,7 @@ const sections = [
     patterns: ["node-operation/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
+      null: ["[Home](/)"],
       Overview: [
         "node-operation/index",
         "node-operation/node-setup",
@@ -221,7 +237,8 @@ const sections = [
     patterns: ["emulator/**/*"],
     sidebarAlwaysExpanded: true,
     sidebar: {
-      null: ["emulator/index", "emulator/changelog"],
+      null: ["[Home](/)"],
+      Overview: ["emulator/index", "emulator/changelog"],
     },
   },
   {
@@ -283,6 +300,7 @@ module.exports = {
         baseUrl: "https://docs.onflow.org",
         twitterUrl: "https://twitter.com/flow_blockchain",
         discordUrl: "https://discord.gg/flow",
+        discourseUrl: "https://forum.onflow.org",
         logoLink: "/",
         root: __dirname,
         githubAccessToken: process.env.GITHUB_ACCESS_TOKEN, // https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token

--- a/docs/plugins/gatsby-theme-flow/gatsby-node.js
+++ b/docs/plugins/gatsby-theme-flow/gatsby-node.js
@@ -176,7 +176,6 @@ async function createPagesForSection(
     sourceSlugTransformers,
   }
 ) {
-  console.log(discordUrl, discourseUrl);
 
   const allPages = await Promise.all(
     section.patterns.map(async (pattern) => {

--- a/docs/plugins/gatsby-theme-flow/gatsby-node.js
+++ b/docs/plugins/gatsby-theme-flow/gatsby-node.js
@@ -169,12 +169,15 @@ async function createPagesForSection(
     baseDir = "",
     subtitle,
     discordUrl,
+    discourseUrl,
     twitterUrl,
     baseUrl,
     sourceGithubRepos,
     sourceSlugTransformers,
   }
 ) {
+  console.log(discordUrl, discourseUrl);
+
   const allPages = await Promise.all(
     section.patterns.map(async (pattern) => {
       const { data } = await graphql(`
@@ -256,10 +259,11 @@ async function createPagesForSection(
         sidebar: {
           showMainNav: section.sidebarShowMainNav,
           alwaysExpanded: section.sidebarAlwaysExpanded,
-          contents: sidebarContents
+          contents: sidebarContents,
         },
         githubUrl,
         discordUrl,
+        discourseUrl,
         twitterUrl,
         baseUrl,
       },

--- a/docs/plugins/gatsby-theme-flow/src/components/page-content.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/page-content.js
@@ -4,7 +4,7 @@ import SectionNav from "./section-nav";
 import styled from "@emotion/styled";
 import useMount from "react-use/lib/useMount";
 import { HEADER_HEIGHT } from "../utils";
-import { IconGithub, IconDiscord, IconPlayground } from "../ui/icons";
+import { IconGithub, IconDiscourse, IconPlayground } from "../ui/icons";
 import { theme } from "../colors";
 import { smallCaps } from "../utils/typography";
 import breakpoints from "../utils/breakpoints";
@@ -211,9 +211,9 @@ export default function PageContent(props) {
           />
         )}
         {editLink}
-        {props.discordUrl && (
-          <AsideLink href={props.discordUrl}>
-            <IconDiscord /> Discuss on Discord
+        {props.discourseUrl && (
+          <AsideLink href={props.discourseUrl}>
+            <IconDiscourse /> Discuss on Discourse
           </AsideLink>
         )}
         {props.playgroundUrl && (
@@ -235,5 +235,6 @@ PageContent.propTypes = {
   title: PropTypes.string.isRequired,
   headings: PropTypes.array.isRequired,
   discordUrl: PropTypes.string,
+  discourseUrl: PropTypes.string,
   playgroundUrl: PropTypes.string,
 };

--- a/docs/plugins/gatsby-theme-flow/src/components/sidebar-nav.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/sidebar-nav.js
@@ -198,17 +198,17 @@ function getStylesForNavItem(page) {
         -20px -20px 60px #2587f6`,
         background: colors.blue.lightest,
       };
-    case "Cadence Language Reference":
-      return {
-        color: colors.grey.dark,
-        padding: "0 0.2rem",
-        paddingLeft: "1rem",
-        marginLeft: "-1rem",
-        borderRadius: "1000px",
-        boxShadow: ` 20px 20x 60px #1b63b6, 
-          -20px -20px 60px #2587f6`,
-        background: colors.pink.lightest,
-      };
+    // case "Cadence Language Reference":
+    //   return {
+    //     color: colors.grey.dark,
+    //     padding: "0 0.2rem",
+    //     paddingLeft: "1rem",
+    //     marginLeft: "-1rem",
+    //     borderRadius: "1000px",
+    //     boxShadow: ` 20px 20x 60px #1b63b6,
+    //       -20px -20px 60px #2587f6`,
+    //     background: colors.pink.lightest,
+    //   };
     default:
       return {};
   }
@@ -292,7 +292,7 @@ export default function SidebarNav(props) {
 
   return (
     <>
-      {props.showMainNav &&
+      {props.showMainNav && (
         <DocsetMenuWrapper>
           {docset
             .filter((navItem) => {
@@ -309,7 +309,7 @@ export default function SidebarNav(props) {
               );
             })}
         </DocsetMenuWrapper>
-      }
+      )}
       {root && (
         <NavItems
           pages={root.pages}

--- a/docs/plugins/gatsby-theme-flow/src/components/sidebar-nav.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/sidebar-nav.js
@@ -198,17 +198,6 @@ function getStylesForNavItem(page) {
         -20px -20px 60px #2587f6`,
         background: colors.blue.lightest,
       };
-    // case "Cadence Language Reference":
-    //   return {
-    //     color: colors.grey.dark,
-    //     padding: "0 0.2rem",
-    //     paddingLeft: "1rem",
-    //     marginLeft: "-1rem",
-    //     borderRadius: "1000px",
-    //     boxShadow: ` 20px 20x 60px #1b63b6,
-    //       -20px -20px 60px #2587f6`,
-    //     background: colors.pink.lightest,
-    //   };
     default:
       return {};
   }

--- a/docs/plugins/gatsby-theme-flow/src/components/templates/base.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/templates/base.js
@@ -1,13 +1,13 @@
-import CustomSEO from '../custom-seo';
-import Footer from '../footer';
-import PageContent from '../page-content';
-import PageHeader from '../page-header';
-import PropTypes from 'prop-types';
-import React, {Fragment} from 'react';
-import rehypeReact from 'rehype-react';
-import styled from '@emotion/styled';
-import ContentWrapper from '../content-wrapper';
-import {Markdown, components} from '../markdown';
+import CustomSEO from "../custom-seo";
+import Footer from "../footer";
+import PageContent from "../page-content";
+import PageHeader from "../page-header";
+import PropTypes from "prop-types";
+import React, { Fragment } from "react";
+import rehypeReact from "rehype-react";
+import styled from "@emotion/styled";
+import ContentWrapper from "../content-wrapper";
+import { Markdown, components } from "../markdown";
 
 const StyledContentWrapper = styled(ContentWrapper)({
   paddingBottom: 0,
@@ -16,27 +16,31 @@ const StyledContentWrapper = styled(ContentWrapper)({
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
-  components
+  components,
 }).Compiler;
 
 export default function BaseTemplate(props) {
-  const {hash, pathname} = props.location;
-  const {file, site} = props.data;
-  const {frontmatter, headings, fields} = file.childMarkdownRemark || file.childMdx;
-  const {title, description} = site.siteMetadata;
+  const { hash, pathname } = props.location;
+  const { file, site } = props.data;
+  const { frontmatter, headings, fields } =
+    file.childMarkdownRemark || file.childMdx;
+  const { title, description } = site.siteMetadata;
   const {
     sidebar,
     githubUrl,
     discordUrl,
+    discourseUrl,
     twitterUrl,
-    baseUrl
+    baseUrl,
   } = props.pageContext;
+
+  console.log(props.pageContext);
 
   const allHeadings = headings.concat(props.extraHeadings || []);
 
   const pages = sidebar.contents
-    .reduce((acc, {pages}) => acc.concat(pages), [])
-    .filter(page => !page.anchor);
+    .reduce((acc, { pages }) => acc.concat(pages), [])
+    .filter((page) => !page.anchor);
 
   return (
     <Fragment>
@@ -60,6 +64,7 @@ export default function BaseTemplate(props) {
           hash={hash}
           githubUrl={githubUrl}
           discordUrl={discordUrl}
+          discourseUrl={discourseUrl}
         >
           {file.childMdx ? (
             <Markdown>{file.childMdx.body}</Markdown>
@@ -77,5 +82,5 @@ export default function BaseTemplate(props) {
 BaseTemplate.propTypes = {
   data: PropTypes.object.isRequired,
   pageContext: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired
+  location: PropTypes.object.isRequired,
 };

--- a/docs/plugins/gatsby-theme-flow/src/ui/icons.js
+++ b/docs/plugins/gatsby-theme-flow/src/ui/icons.js
@@ -29,6 +29,7 @@ export {
   FaChevronDown as IconChevronDown,
   FaChevronUp as IconChevronUp,
   FaDiscord as IconDiscord,
+  FaDiscourse as IconDiscourse,
   FaExclamationTriangle as IconWarningSolid,
   FaExternalLinkAlt as IconExternalLink,
   FaFacebook as IconFlow, // TODO: replace with real Flow logo,


### PR DESCRIPTION
## Description

- Adds Home link to section nav. 
- Organizes section nav into "Overview" & "Developer Guides" for _all sections_
- Replaces "Discuss on Discord" with "Discuss on Discourse" in right-hand menu per @githubwei 