### PR TITLE
Add full weight token admin keys to LockedTokens reference

### DIFF
--- a/docs/content/protocol/core-contracts/locked-tokens.mdx
+++ b/docs/content/protocol/core-contracts/locked-tokens.mdx
@@ -44,12 +44,14 @@ The shared account is used to store all locked FLOW owned by a token holder.
 The token admin public key is used by account creators to configure token holder
 accounts to hold locked FLOW.
 
-_Note: these keys have a weight of `100`._
+### Token Admin Public Key
 
-| Network | Token Admin Public Key |
-|---------|------------------------|
-| Testnet | `f845b840fd8c6a3078ea6b7ecb96d914832ee3b62323d4d42860235b4a175d75544f476aeb800e3a4bad2cc5375e47fc5e13356167a4512b6ad03e660c04b6db26246cba020364` |
-| Mainnet | `f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164` |
+| Purpose      | Network | Weight | Encoded Key |
+|--------------|---------|--------|------------------------|
+| **Standard** | Testnet | 100    | `f845b840fd8c6a3078ea6b7ecb96d914832ee3b62323d4d42860235b4a175d75544f476aeb800e3a4bad2cc5375e47fc5e13356167a4512b6ad03e660c04b6db26246cba020364` |
+| **Lease**    | Testnet | 1000   | `f847b840fd8c6a3078ea6b7ecb96d914832ee3b62323d4d42860235b4a175d75544f476aeb800e3a4bad2cc5375e47fc5e13356167a4512b6ad03e660c04b6db26246cba02038203e8` |
+| **Standard** | Mainnet | 100    | `f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164` |
+| **Lease**    | Mainnet | 1000   | `f847b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e02018203e8` |
 
 | ID        | Name                    | Source |
 |-----------|-------------------------|--------|


### PR DESCRIPTION
## Description

This PR adds the token admin keys used to configure accounts to hold leased FLOW.
