### PR TITLE
NFT tutorial contract comment corrections

### DIFF
--- a/docs/content/cadence/tutorial/04-non-fungible-tokens.mdx
+++ b/docs/content/cadence/tutorial/04-non-fungible-tokens.mdx
@@ -205,7 +205,7 @@ pub contract ExampleNFT {
         // The unique ID that differentiates each NFT
         pub let id: UInt64
 
-        // Initialize both fields in the init function
+        // Initialize the field in the init function
         init(initID: UInt64) {
             self.id = initID
         }
@@ -458,9 +458,9 @@ Open the script file named `Print 0x02 NFTs`.
 ```cadence
 import ExampleNFT from 0x02
 
-// Print the NFTs owned by account 0x03.
+// Print the NFTs owned by account 0x02.
 pub fun main() {
-    // Get the public account object for account 0x03
+    // Get the public account object for account 0x02
     let nftOwner = getAccount(0x02)
 
     // Find the public Receiver capability for their Collection


### PR DESCRIPTION
Changed comment on line 208 of NFTv2.cdc to correctly state that only a single field is initialized in the init function (likely a remnant of copy/paste from example one using metadata and id).

Changed comment on line 461 to correctly reference printing NFTs owned by account 0x02 instead of 0x03

Changed comment on line 463 to correctly reference getting the public account object for account 0x02 instead of 0x03

Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
