### PR TITLE
Fix link to /concepts/mainent

### DIFF
--- a/docs/content/node-operation/faq.mdx
+++ b/docs/content/node-operation/faq.mdx
@@ -57,7 +57,7 @@ Yes, as long as you retain the `boostrap` information which includes the node st
 
 ### Is there a public node?
 
-Yes, an access node is [publicly accessible](/concepts/mainnet.mdx) to submit transactions and read data from the blockchain using the
+Yes, an access node is [publicly accessible](/concepts/mainnet) to submit transactions and read data from the blockchain using the
 [Access API](/core-contracts/access-api).
 
 ### Where can I find how many nodes are currently running Flow?


### PR DESCRIPTION
## Description
- Remove `.mdx` extension from link to `/concepts/mainnet`
