### PR TITLE
fix example spacing in fungible-token tutorial

### DIFF
--- a/docs/content/cadence/tutorial/03-fungible-tokens.mdx
+++ b/docs/content/cadence/tutorial/03-fungible-tokens.mdx
@@ -460,7 +460,7 @@ pub contract ExampleToken {
         // We say `&AnyResource{Receiver}` to say that the recipient can be any resource
         // as long as it implements the Receiver interface
         pub fun mintTokens(amount: UFix64, recipient: &AnyResource{Receiver}) {
-                  ExampleToken.totalSupply = ExampleToken.totalSupply + UFix64(amount)
+            ExampleToken.totalSupply = ExampleToken.totalSupply + UFix64(amount)
             recipient.deposit(from: <-create Vault(balance: amount))
         }
     }


### PR DESCRIPTION

## Description

small section of the tutorial fungible token contract had incorrect indentation "ExampleToken.cdc"
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
