### PR TITLE
Fix Storage Links

### DIFF
--- a/docs/content/concepts/storage.mdx
+++ b/docs/content/concepts/storage.mdx
@@ -61,4 +61,6 @@ pub fun main(address: Address) {
 
 ## Further reading
 
-The **FLIP** (Flow Improvement Proposal) for storage fees can be found here: [https://github.com/onflow/flow/blob/9b80e46967cf4bdbe0e433744b9fc2ec773cdb55/flips/20201310-storage-fees.md](https://github.com/onflow/flow/blob/9b80e46967cf4bdbe0e433744b9fc2ec773cdb55/flips/20201310-storage-fees.md).
+Relevant Cadence changes can be found here: [https://docs.onflow.org/cadence/language/accounts#account-storage](https://docs.onflow.org/cadence/language/accounts#account-storage)
+
+The **FLIP** (Flow Improvement Proposal) for storage fees can be found here: [20201310-storage-fees.md](https://github.com/onflow/flow/blob/janez/storage-fees/flips/20201310-storage-fees.md).


### PR DESCRIPTION

## Description

- Fixed the storage fees linking to an older version of the doc.
- Added a link to the cadence part of the changes.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
