### PR TITLE
Update Node Operator Docs

### DIFF
--- a/docs/content/node-operation/guides/genesis-bootstrap.mdx
+++ b/docs/content/node-operation/guides/genesis-bootstrap.mdx
@@ -111,7 +111,7 @@ In phase 2 of the bootstrapping process, the Flow team will need to securely iss
 {
 "codes": [
 {
-"code": "# If you joined our network previously, make sure to take a backup!\ncp /path/to/bootstrap /path/to/bootstrap.bak\n$ ./boot-tools/transit -push -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}\nRunning push\nGenerating keypair\nUploading ...\nUploaded 400 bytes",
+"code": "# If you joined our network previously, make sure to take a backup!\ncp /path/to/bootstrap /path/to/bootstrap.bak\n$ ./boot-tools/transit push -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}\nRunning push\nGenerating keypair\nUploading ...\nUploaded 400 bytes",
 "language": "shell",
 "name": "Upload public keys"
 }
@@ -155,7 +155,7 @@ When the Flow team gives the go-ahead, your Random Beacon keys will be available
 {
 "codes": [
 {
-"code": "~ $ ./boot-tools/transit -pull -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}\nFetching keys for node ID FEF5CCFD-DC66-4EF6-8ADB-C93D9B6AE5A4\nDecrypting Keys\nKeys available",
+"code": "~ $ ./boot-tools/transit pull -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}\nFetching keys for node ID FEF5CCFD-DC66-4EF6-8ADB-C93D9B6AE5A4\nDecrypting Keys\nKeys available",
 "language": "shell",
 "name": "Pull beacon keys"
 }

--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -132,7 +132,7 @@ $tree ./bootstrap/
 </Callout>
 
 ```shell
-$ ./boot-tools/transit -push -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}
+$ ./boot-tools/transit push -d ./bootstrap -t ${TOKEN} -role ${YOUR_NODE_ROLE}
 
 Running push
 Generating keypair
@@ -216,17 +216,14 @@ The Flow team will provide you a new token `PULL_TOKEN` to pull the genesis info
 </Callout>
 
 1. Run the transit script to fetch the new genesis info:
-   `./boot-tools/transit -pull -d ./bootstrap -t ${PULL_TOKEN} -role ${YOUR_NODE_TYPE}`
+   `./boot-tools/transit pull -d ./bootstrap -t ${PULL_TOKEN} -role ${YOUR_NODE_TYPE}`
 
 ```shell:title=Example
-$ ./boot-tools/transit -pull -d ./bootstrap -t mainnet-6  -role consensus
+$ ./boot-tools/transit pull -d ./bootstrap -t mainnet-6  -role consensus
 Transit script Commit: a9f6522855e119ad832a97f8b7bce555a163e490
 2020/11/25 01:02:53 Running pull
 2020/11/25 01:02:53 Downloading bootstrap/public-root-information/node-infos.pub.json
-2020/11/25 01:02:53 Downloading bootstrap/public-root-information/root-block-seal.json
-2020/11/25 01:02:53 Downloading bootstrap/public-root-information/root-block.json
-2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-execution-result.json
-2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-qc.json
+2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-protocol-snapshot.json
 2020/11/25 01:02:54 Downloading bootstrap/random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.enc
 2020/11/25 01:02:54 MD5 of the root block is: 2c9c7bba641a4ea34b6c49d5957ef058
 
@@ -239,10 +236,7 @@ $ tree ./bootstrap/
   │   ├── node-id
   │   ├── node-info.pub.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.json
   │   ├── node-infos.pub.json
-  │   ├── root-block-seal.json
-  │   ├── root-block.json
-  │   ├── root-execution-result.json
-  │   └── root-qc.json
+  │   └── root-protocol-snapshot.json
   └── random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a
 ```
 


### PR DESCRIPTION
Closes: https://github.com/dapperlabs/flow-go/issues/5287

## Description

This PR update the Node operator document to take into account the updated Transit CLI commands and the unified protocol state bootstrap file `root-protocol-snapshot.json` instead of the `root-qc.json`, `root-block.json`, etc..