### PR TITLE
Fix a typo in developers.mdx

### DIFF
--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -163,7 +163,7 @@ You can find details about accessing Flow mainnet here [https://docs.onflow.org/
 
 The access is via a GRPC interface. Transactions can also be submitted using the GRPC [SendTransaction call](https://docs.onflow.org/access-api#sendtransaction). A GRPC client written in any language should be able to talk via the Access API. We have a [Go SDK](https://github.com/onflow/flow-go-sdk) and a [JavaScript SDK](https://github.com/onflow/flow-js-sdk) that can be used if you are using a Go based or a JS based client respectively.
 
-## What's the difference between a mainnet spork and testtet spork? How do sporks affect TopShot?
+## What's the difference between a mainnet spork and testnet spork? How do sporks affect TopShot?
 
 The Mainnet and Testnet are two separate networks. The difference is which network will be undergoing the down time. Since the main application for NBA TopShot exists on Mainnet, only Mainnet sporks will affect the main applications uptime.
 


### PR DESCRIPTION
## Description

Fix typo by replacing "testtet" with "testnet" in Buliders/Developers FAQ.

#### Caveats

I can open an issue if desired (prior pull requests for simple updates to docs didn't appear have one).  
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.  (See Caveats)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
