### PR TITLE
Update rewards.mdx

### DIFF
--- a/docs/content/staking/rewards.mdx
+++ b/docs/content/staking/rewards.mdx
@@ -21,7 +21,7 @@ providers might require extra steps to withdraw user staking reward so please co
 provider to get additional information as needed.
 
 **Epochs end at 10:00pm PT Tuesday (06:00 GMT Wednesday)**, every week, with the next epoch beginning immediately. 
-Please note that staking requests will be processed by the protocol at the start of the next epoch. 
+Please note that all staking operations that interact with staked tokens will be processed by the protocol at the start of each epoch. 
 
 
 ## Rewards Distribution
@@ -71,4 +71,3 @@ Because of the variable nature of the rewards calculation, we cannot provide an 
 for a single staker. You can plug your own numbers into the formula to see some sample calculations, 
 but you won't be able to know exactly what you will earn until the beginning 
 of the epoch in which you are participating in staking or delegation.
-

--- a/docs/content/staking/rewards.mdx
+++ b/docs/content/staking/rewards.mdx
@@ -14,16 +14,15 @@ core team and community. If any changes are proposed, the Flow community will be
 
 # Rewards
 
-**Rewards are paid at 6:00am PT (14:00 GMT) on Tuesday**, every week,
-to all the users that have tokens staked. 
+**Rewards are paid at 10:00pm PT (06:00 GMT Wednesday) on Tuesday**, every week, to all users that have tokens staked. 
 
-Once distributed, rewards are unlocked and liquid, so they can be transferred at any time. 
-Some custody providers might require extra steps to withdraw user staking reward 
-so please contact your respective provider to get additional information as needed.
+Once distributed, rewards are unlocked and liquid, so they can be transferred at any time. Some custody 
+providers might require extra steps to withdraw user staking reward so please contact your respective 
+provider to get additional information as needed.
 
-**Epochs end at 10:00pm PT Tuesday (06:00 GMT Wednesday)**, every week. This means that
-reward recipients have approximately 16 hours to commit the rewards they receive in order
-for the rewards to be staked in the next epoch.
+**Epochs end at 10:00pm PT Tuesday (06:00 GMT Wednesday)**, every week, with the next epoch beginning immediately. 
+Please note that staking requests will be processed by the protocol at the start of the next epoch. 
+
 
 ## Rewards Distribution
 


### PR DESCRIPTION
Updating epoch ending time to match with our new model going forward

Closes: #???

## Description

We are pushing out a new epoch update where epochs will end first and rewards will be paid out right after, there won't be a gap between reward payment and next epoch start.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
