### PR TITLE
Do not force-unwrap (now) non-optional result of getCapability

### DIFF
--- a/docs/content/cadence/tutorial/03-fungible-tokens.mdx
+++ b/docs/content/cadence/tutorial/03-fungible-tokens.mdx
@@ -48,7 +48,7 @@ We're going to take you through these steps to get comfortable with the fungible
 5. Transfer tokens from one account to another.
 6. Use a script to read the accounts' balances.
 
-**Before proceeding with this tutorial**, we recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/) 
+**Before proceeding with this tutorial**, we recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/)
 and [Hello, World!](/cadence/tutorial/02-hello-world/) to learn the basics of the language and the playground.
 
 <!-- For additional support, see the [Playground Manual](doc:playground-manual) -->
@@ -138,7 +138,7 @@ each account owns a resource object in their account storage that records the nu
 This way, when users want to transact with each other, they can do so peer-to-peer without having to interact with a central token contract.
 To transfer tokens to each other, they call a `transfer` function (or something equivalent) on their own resource object and other users' resources, instead of a central `transfer` function.
 
-This approach simplifies access control because instead of a central contract having to check the sender of a function call, 
+This approach simplifies access control because instead of a central contract having to check the sender of a function call,
 most function calls happen on resource objects stored in users' account, and each user controls who is able to call the functions on resources in their account.
 This concept, called Capability-based security, will be explained more in a later section.
 
@@ -302,7 +302,7 @@ pub resource interface Receiver {
 ```
 
 In our example, the `Vault` resource would implement both of these interfaces.
-The interfaces ensure that specific fields and functions are present in the resource implementation 
+The interfaces ensure that specific fields and functions are present in the resource implementation
 and that those functions meet certain conditions before and/or after execution.
 These interfaces can be stored on-chain and imported into other contracts or resources
 so that these requirements are enforced by an immutable source of truth that is not susceptible to human error.
@@ -497,7 +497,7 @@ Click the `Deploy` button at the bottom right of the editor to deploy the code.
 
 This deployment stores the contract for the fungible token in your active account (account `0x01`) so that it can be imported into transactions.
 
-A contract's `init` function runs at contract creation, and never again afterwards. 
+A contract's `init` function runs at contract creation, and never again afterwards.
 In our example, this function stores an instance of the `Vault` object with an initial balance of 30, and stores the `VaultMinter` object that you can use to mint new tokens.
 
 ```cadence
@@ -519,8 +519,8 @@ Account storage is indexed with paths, which consist of a domain and identifier.
 Contracts have access to the private `AuthAccount` object of the account it is deployed to, using `self.account`.
 This object has methods that can modify storage in many ways. See the [account](/cadence/language/accounts) documentation for a list of all the methods it can call.
 
-In this line, we call the `save` method to store an object in storage. 
-The first argument is the value to store, and the second argument is the path where the value is being stored. 
+In this line, we call the `save` method to store an object in storage.
+The first argument is the value to store, and the second argument is the path where the value is being stored.
 For `save` the path has to be in the `/storage` domain.
 
 We also store the `VaultMinter` object to `/storage/` in the next line in the same way:
@@ -529,7 +529,7 @@ We also store the `VaultMinter` object to `/storage/` in the next line in the sa
 self.account.save(<-create VaultMinter(), to: /storage/MainMinter)
 ```
 
-You should also see that the `ExampleToken.Vault` and `ExampleToken.VaultMinter` resource objects are stored in the account storage. 
+You should also see that the `ExampleToken.Vault` and `ExampleToken.VaultMinter` resource objects are stored in the account storage.
 This will be shown in the Resources box at the bottom of the screen.
 
 You are now ready to run transactions that use the fungible tokens!
@@ -538,11 +538,11 @@ You are now ready to run transactions that use the fungible tokens!
 
 ---
 
-Capabilities are like pointers in other languages. They are a link to an object in an account's storage 
+Capabilities are like pointers in other languages. They are a link to an object in an account's storage
 and can be used to read fields or call functions on the object they reference. They cannot move or modify the object directly.
 
-There are many different situations in which you would create a capability to your fungible token vault. 
-You might want a simple way to call methods on your `Vault` from anywhere in a transaction. 
+There are many different situations in which you would create a capability to your fungible token vault.
+You might want a simple way to call methods on your `Vault` from anywhere in a transaction.
 You could also send a capability that only exposes withdraw function in your `Vault` so that others can transfer tokens for you.
 You could also have one that only exposes the `Balance` interface, so that others can check how many tokens you own.
 There could also be a function that takes a capability to a `Vault` as an argument, borrows a reference to the capability,
@@ -580,7 +580,7 @@ Open the transaction named `Create Link`. <br/>
 ```cadence:title=Create Link.cdc
 import ExampleToken from 0x01
 
-// This transaction creates a capability 
+// This transaction creates a capability
 // that is linked to the account's token vault.
 // The capability is restricted to the fields in the `Receiver` interface,
 // so it can only be used to deposit funds into the account.
@@ -588,8 +588,8 @@ transaction {
   prepare(acct: AuthAccount) {
 
     // Create a link to the Vault in storage that is restricted to the
-    // fields and functions in `Receiver` and `Balance` interfaces, 
-    // this only exposes the balance field 
+    // fields and functions in `Receiver` and `Balance` interfaces,
+    // this only exposes the balance field
     // and deposit function of the underlying vault.
     //
     acct.link<&ExampleToken.Vault{ExampleToken.Receiver, ExampleToken.Balance}>(/public/MainReceiver, target: /storage/MainVault)
@@ -599,8 +599,8 @@ transaction {
 
   post {
     // Check that the capabilities were created correctly
-    // by getting the public capability and checking 
-    // that it points to a valid `Vault` object 
+    // by getting the public capability and checking
+    // that it points to a valid `Vault` object
     // that implements the `Receiver` interface
     getAccount(0x01).getCapability<&ExampleToken.Vault{ExampleToken.Receiver}>(/public/MainReceiver)
                     .check():
@@ -610,9 +610,9 @@ transaction {
 ```
 
 In order to use a capability, we have to first create a link to that object in storage.
-A reference can then be created from a capability, and references cannot be stored. 
-They need to be lost at the end of a transaction execution. 
-This restriction is to prevent reentrancy attacks which are attacks where a malicious user calls into the same function over and over again 
+A reference can then be created from a capability, and references cannot be stored.
+They need to be lost at the end of a transaction execution.
+This restriction is to prevent reentrancy attacks which are attacks where a malicious user calls into the same function over and over again
 before the original execution has finished. Only allowing one reference at a time for an object prevents these attacks for objects in storage.
 
 To create a capability, we use the `link` function.
@@ -652,7 +652,7 @@ getAccount(0x01).getCapability(/public/MainReceiver)
 ```
 
 The `post` phase is for ensuring that certain conditions are met after the transaction has been executed.
-Here, we are getting the capability from its public path and calling its `check` function to ensure 
+Here, we are getting the capability from its public path and calling its `check` function to ensure
 that the capability contains a valid link to a valid object in storage that is the specified type.
 
 <Callout type="info">
@@ -667,11 +667,11 @@ This transaction creates a new public reference to your `Vault` and checks that 
 
 ---
 
-Now, we are going to run a transaction that sends 10 tokens to account `0x02`. We will do this by calling the `withdraw` function on account `0x01`'s Vault, 
+Now, we are going to run a transaction that sends 10 tokens to account `0x02`. We will do this by calling the `withdraw` function on account `0x01`'s Vault,
 which creates a temporary Vault object for moving the tokens, then deposits those tokens into account `0x02`'s account by calling their `deposit` function.
 
 Here we encounter another safety feature that Cadence introduces. Owning tokens requires you to have a `Vault` object stored in your account,
-so if anyone tries to send tokens to an account who isn't prepared to receive them, the transaction will fail. 
+so if anyone tries to send tokens to an account who isn't prepared to receive them, the transaction will fail.
 This way, Cadence protects the user if they accidentally enter the account address incorrectly when sending tokens.
 
 Account `0x02` has not been set up to receive tokens, so we will do that now:
@@ -805,7 +805,7 @@ then use the `borrow` function on the capability to get the reference from it, t
 
 ```cadence
 // Get the public receiver capability
-let cap = recipient.getCapability(/public/MainReceiver)!
+let cap = recipient.getCapability(/public/MainReceiver)
 
 // Borrow a reference from the capability
 self.receiverRef = cap.borrow<&ExampleToken.Vault{ExampleToken.Receiver}>()
@@ -888,7 +888,7 @@ If correct, you should see the following lines:
 Result > "void"
 ```
 
-If there is an error, this probably means that you missed a step earlier 
+If there is an error, this probably means that you missed a step earlier
 and might need to restart from the beginning.
 
 To restart the playground, close your current session and open the link at the top of the tutorial.

--- a/docs/content/flow-token/wallets.mdx
+++ b/docs/content/flow-token/wallets.mdx
@@ -47,7 +47,7 @@ Here's how you deposit FLOW into an account:
 
 ```cadence
 let receiver = account
-  .getCapability(/public/flowTokenReceiver)!
+  .getCapability(/public/flowTokenReceiver)
   .borrow<&{FungibleToken.Receiver}>()
     ?? panic("Could not borrow FungibleToken.Receiver reference")
 
@@ -167,7 +167,7 @@ to fetch the balance of an account directly in code.
 
 ```cadence
 let balanceRef = account
-  .getCapability(/public/flowTokenBalance)!
+  .getCapability(/public/flowTokenBalance)
   .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
     ?? panic("Could not borrow FungibleToken.Balance reference")
 
@@ -227,9 +227,9 @@ transaction(amount: UFix64, to: Address) {
     let recipient = getAccount(to)
 
     // Get a reference to the recipient's FungibleToken.Receiver
-    let receiver = recipient.
-      getCapability(/public/flowTokenReceiver)!.
-      borrow<&{FungibleToken.Receiver}>()
+    let receiver = recipient
+      .getCapability(/public/flowTokenReceiver)
+      .borrow<&{FungibleToken.Receiver}>()
         ?? panic("Could not borrow receiver reference to the recipient's Vault")
 
     // Deposit the withdrawn tokens in the recipient's receiver

--- a/docs/content/fusd/testnet.md
+++ b/docs/content/fusd/testnet.md
@@ -97,7 +97,7 @@ transaction(amount: UFix64, to: Address) {
 
     // Get a reference to the recipient's Receiver
     let receiverRef = recipient
-      .getCapability(/public/fusdReceiver)!
+      .getCapability(/public/fusdReceiver)
       .borrow<&{FungibleToken.Receiver}>()
       ?? panic("Could not borrow receiver reference to the recipient's Vault")
 
@@ -119,7 +119,7 @@ pub fun main(address: Address): UFix64 {
   let account = getAccount(address)
 
   let vaultRef = account
-    .getCapability(/public/fusdBalance)!
+    .getCapability(/public/fusdBalance)
     .borrow<&FUSD.Vault{FungibleToken.Balance}>()
     ?? panic("Could not borrow Balance capability")
 

--- a/docs/content/transaction-templates.mdx
+++ b/docs/content/transaction-templates.mdx
@@ -15,7 +15,7 @@ transaction(amount: UFix64, to: Address) {
 
     execute {
         getAccount(to)
-            .getCapability(/public/flowTokenReceiver)!
+            .getCapability(/public/flowTokenReceiver)
             .borrow<&{FungibleToken.Receiver}>()!
             .deposit(from: <-self.vault)
     }


### PR DESCRIPTION
https://forum.onflow.org/t/force-unwrap-vs-optional-chaining/1962 had me check the docs, and there were still some cases where the result of `getCapability` was unnecessarily force-unwrapped.

(The forum question was regarding linking, which still returns an optional, so no changes needed theree)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
