### PR TITLE
Update MD5 -> SHA256

### DIFF
--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -225,7 +225,7 @@ Transit script Commit: a9f6522855e119ad832a97f8b7bce555a163e490
 2020/11/25 01:02:53 Downloading bootstrap/public-root-information/node-infos.pub.json
 2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-protocol-snapshot.json
 2020/11/25 01:02:54 Downloading bootstrap/random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.enc
-2020/11/25 01:02:54 MD5 of the root block is: 2c9c7bba641a4ea34b6c49d5957ef058
+2020/11/25 01:02:54 SHA of the root block is: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 $ tree ./bootstrap/
   ./bootstrap/

--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -225,7 +225,7 @@ Transit script Commit: a9f6522855e119ad832a97f8b7bce555a163e490
 2020/11/25 01:02:53 Downloading bootstrap/public-root-information/node-infos.pub.json
 2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-protocol-snapshot.json
 2020/11/25 01:02:54 Downloading bootstrap/random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.enc
-2020/11/25 01:02:54 SHA of the root block is: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+2020/11/25 01:02:54 SHA256 of the root block is: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 $ tree ./bootstrap/
   ./bootstrap/

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -445,6 +445,6 @@
       "source": "/flow-js-sdk",
       "destination": "/fcl",
       "permanent": false
-    },
+    }
   ]
 }


### PR DESCRIPTION
Do not merge before https://github.com/onflow/flow-go/pull/990/ is merged.
This PR updates our file-based user-visible hashes from MD5 to SHA256, a better, yet widely available hash function.

The present PR does the same for the doc, at least in the format of the displayed hashes, rather than actual content: the doc is not updated at every Spork, and the output updated in this PR is here for demonstration only.
