### PR TITLE
Storage parameters update in docs

### DIFF
--- a/docs/content/concepts/storage.mdx
+++ b/docs/content/concepts/storage.mdx
@@ -12,10 +12,10 @@ Storage capacity of an account is dictated by the amount of FLOW it has. **The m
 
 The exact amount of storage capacity an account has is the amount of FLOW the account has times the `storageBytesPerReservedFlow` variable defined on the `StorageFees` smart contract, which is:
 
-- 10 MB per 1 reserved FLOW, or
-- 1 MB per 0.1 reserved FLOW, or
-- 100 kB per 0.01 reserved FLOW, or
-- 10 kB per 0.001 reserved FLOW.
+- 100 MB per 1 reserved FLOW, or
+- 10 MB per 0.1 reserved FLOW, or
+- 1 kB per 0.01 reserved FLOW, or
+- 100 kB per 0.001 reserved FLOW.
 
 Any account can increase the storage capacity of an account by depositing more FLOW to the account.
 
@@ -37,8 +37,8 @@ Data stored on the Flow blockchain is stored in a key-value ledger. Each item’
 
 Two parameters define storage limits:
 
-- Minimum account FLOW is **0.001 FLOW** and represents **10 kB** of storage capacity. This is also the amount of FLOW that the creator of a new account needs to provide for the account's storage reservation. (`StorageFees.minimumStorageReservation`)
-- The amount of storage capacity one FLOW represents is **10 MB per FLOW**. (`StorageFees.storageMegaBytesPerReservedFlow`)
+- Minimum account FLOW is **0.001 FLOW** and represents **100 kB** of storage capacity. This is also the amount of FLOW that the creator of a new account needs to provide for the account's storage reservation. (`StorageFees.minimumStorageReservation`)
+- The amount of storage capacity one FLOW represents is **100 MB per FLOW**. (`StorageFees.storageMegaBytesPerReservedFlow`)
 
 ## FAQ
 

--- a/docs/content/concepts/storage.mdx
+++ b/docs/content/concepts/storage.mdx
@@ -14,7 +14,7 @@ The exact amount of storage capacity an account has is the amount of FLOW the ac
 
 - 100 MB per 1 reserved FLOW, or
 - 10 MB per 0.1 reserved FLOW, or
-- 1 kB per 0.01 reserved FLOW, or
+- 1 MB per 0.01 reserved FLOW, or
 - 100 kB per 0.001 reserved FLOW.
 
 Any account can increase the storage capacity of an account by depositing more FLOW to the account.

--- a/docs/content/flow-token/concepts.mdx
+++ b/docs/content/flow-token/concepts.mdx
@@ -31,7 +31,7 @@ and thus must be paid even if no change to your account is made.
 ### Storage/Account Fees
 
 The account creation fee is applied only when a new account is created.
-This fee covers the cost of storing up to 10kB of data in perpetuity.
+This fee covers the cost of storing up to 100kB of data in perpetuity.
 This fee is applied only once and can be "topped up" to add additional storage to an account.
 
 More information: [Storing Data on Flow](/concepts/storage)


### PR DESCRIPTION
## Description

Update storage parameters in docs.

1 FLOW is now 100 MB (not 10 MB) of storage capacity.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
