### PR TITLE
Fix account.keys -> account.key in config example

### DIFF
--- a/docs/content/dapp-deployment/testnet-deployment.md
+++ b/docs/content/dapp-deployment/testnet-deployment.md
@@ -102,7 +102,7 @@ Add the account created with the use of faucet above to the `accounts` property 
   "accounts": {
     "my-testnet-account": {
       "address": "ADDRESS_FROM_FAUCET",
-      "keys": "SECRET_GENERATED_IN_PREVIOUS_STEP"
+      "key": "PRIVATE_KEY_GENERATED_IN_PREVIOUS_STEP"
     }
   }
 ...


### PR DESCRIPTION
Closes: #???

## Description

Currently the example config uses accounts.keys field, but the correct field to use is account.key. Also updated the
value to read "PRIVATE_KEY_GENERATED_IN_PREVIOUS_STEP" to be even more explicit about which key value 
to fill in.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
