### PR TITLE
Describes Fees usage for rewards

### DIFF
--- a/docs/content/staking/index.mdx
+++ b/docs/content/staking/index.mdx
@@ -29,7 +29,9 @@ If a node ever breaks the rules defined by the network,
 a number of the node operator's staked tokens will be taken from them as a punishment.
 This process is automatic. Every node knows the rules defined by the network
 and automatically watches other nodes and reports them if they misbehave.
-Meanwhile, the network pays the node operator a reward of tokens on a regular basis provided their node does not break the rules.
+Meanwhile, the network pays the node operator a reward from a mixture of
+transaction fees and newly minted tokens
+on a regular basis provided their node does not break the rules.
 
 If a node operator breaks the rules, they lose the tokens they've staked.
 If they operate my node with integrity, they get rewarded with more tokens!
@@ -53,7 +55,8 @@ This timeframe is otherwise known as an **Epoch.**
 
 ## Epochs
 
-An **Epoch** is a roughly week-long period that the network uses to manage list of nodes and pay rewards.
+An **Epoch** is a roughly week-long period that the network uses
+to manage list of nodes and pay rewards.
 
 - Only a pre-determined set of nodes is authorized to participate in the protocol. 
 The set of authorized nodes is known to all network participants.
@@ -95,7 +98,8 @@ of the identity table, epoch schedule, QC, and DKG.
 
 ## Rewards
 
-Please see the [schedule](/staking/schedule) section of the documentation for information about reward calculations and schedule and
+Please see the [schedule](/staking/schedule) section of the documentation
+for information about reward calculations and schedule and
 what you can do with the rewards you earn by staking a node!
 
 ## Delegation

--- a/docs/content/staking/schedule.mdx
+++ b/docs/content/staking/schedule.mdx
@@ -60,6 +60,12 @@ to empower a wide variety of use cases and promote fair and diverse participatio
 The numbers in this table represent the total amount of tokens that are paid 
 as staking rewards at each epoch to the entire pool of participants in the Flow network as a whole. 
 While total staking reward per epoch is known and fixed, individual rewards are variable depending on many factors. 
+
+The total rewards for each epoch are fixed for that epoch, but where those rewards come from can change.
+When the protocol pays rewards, it first pulls from the central pool of all the transaction fees
+that have been paid by every user in the network since the last rewards payment.
+Once that pool has been depleted, the protocol mints new tokens that are used as rewards.
+
 Please see the next section on how to calculate an individual staking reward.
 
 |                               | Dec 22         | Dec 29, Jan 5, 12, 19, 26 | Feb 2 weekly on Tuesdays until Dec 21, 2021 | Weeks 53+  |


### PR DESCRIPTION
## Description

Updates the rewards documentation to describe that transaction fees are used to pay rewards before new tokens are minted
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
