### PR TITLE
Update example pub key log in machine account creation documentation

### DIFF
--- a/docs/content/node-operation/machine-existing-operator.mdx
+++ b/docs/content/node-operation/machine-existing-operator.mdx
@@ -49,17 +49,18 @@ sha256sum ./boot-tools/transit
 You will need to generate a Machine account private key using the `bootstrap` utility.
 
 <Callout type="warning">
+
   Ensure you run the following commands on the machine you use to run your node software.
   The bootstrap directory passed to the `-o` flag must be the same bootstrap directory used by your node.
   The default location is `/var/flow/bootstrap`, but double-check your setup before continuing.
+
 </Callout>
 
 ```shell:title=GenerateMachineAccountKey
 $./boot-tools/bootstrap machine-account-key -o ./bootstrap
 <nil> INF generated machine account private key
-<nil> DBG encoded public machine account key machineAccountPubKey=2743786d1ff1bf7d7026d693a774210eaa54728343859baab62e2df7f71a370651f4c7fd239d07af170e484eedd4f3c2df47103f6c39baf2eb2a50f67bbcba6a
+<nil> INF encode machine account public key for entry to Flow Port machineAccountPubKey=f847b84031d9f47b88435e4ea828310529d2c60e806395da50d3dd0dd2f32e2de336fb44eb06488645673850897d7cc017701d7e6272a1ab7f2f125aede46363e973444a02038203e8
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_6f6e98c983dbd9aa69320452949b81abeab2ac591a247f55f19f4dbf0b477d26/node-machine-account-key.priv.json
-<nil> INF machine account public key: 0x2743786d1ff1bf7d7026d693a774210eaa54728343859baab62e2df7f71a370651f4c7fd239d07af170e484eedd4f3c2df47103f6c39baf2eb2a50f67bbcba6a
 
 $tree ./bootstrap/
 ./bootstrap

--- a/docs/content/node-operation/machine-existing-operator.mdx
+++ b/docs/content/node-operation/machine-existing-operator.mdx
@@ -38,10 +38,10 @@ tar -xvf boot-tools.tar
 
 ```shell:title=CheckSHA256
 sha256sum ./boot-tools/bootstrap
-2b687fbcf5a25074b3a3854f97230432146abc87e3d0a7fac1298ee4c8169b56  ./boot-tools/bootstrap
+4f7034f6977fd1fc0980a2a38640db8d085714f7d928a67365a083886cb85814  ./boot-tools/bootstrap
 
 sha256sum ./boot-tools/transit
-62bb958566c6fde2b2c975eef1c4b8a9d6d5487a9611b97600c1b9d35f8eed9a  ./boot-tools/transit
+d1ef25d67fe339e4ae5bff150fdf814e66dba3e490965d4bb965ed34ea181e03  ./boot-tools/transit
 ```
 
 ## Generate Machine Account key

--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -110,7 +110,7 @@ $./boot-tools/bootstrap key --address "198.123.42.10:3569" --role consensus  -o 
 <nil> DBG will generate machine account key
 <nil> INF generated machine account key
 <nil> DBG assembling machine account information address=198.123.42.10:3569
-<nil> DBG encoded public machine account key machineAccountPubKey=1b9c00e6f0930792c5738d3397169f8a592416f334cf11e84e6327b98691f2b72158b40886a4c3663696f96cd15bfb5a08730e529f62a00c78e2405013a6016d
+<nil> INF encode machine account public key for entry to Flow Port machineAccountPubKey=f847b8406e8969b869014cd1684770a8db02d01621dd1846cdf42fc2bca3444d2d55fe7abf740c548639cc8451bcae0cd6a489e6ff59bb6b38c2cfb83e095e81035e507b02038203e8
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9/node-machine-account-key.priv.json
 
 $tree ./bootstrap/

--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -37,12 +37,13 @@ If you have downloaded the bootstrapping kit previously, ensure that you do this
 curl -sL -O storage.googleapis.com/flow-genesis-bootstrap/boot-tools.tar
 tar -xvf boot-tools.tar
 ```
+
 ```shell:title=CheckSHA256
 sha256sum ./boot-tools/bootstrap
-2b687fbcf5a25074b3a3854f97230432146abc87e3d0a7fac1298ee4c8169b56  ./boot-tools/bootstrap
+4f7034f6977fd1fc0980a2a38640db8d085714f7d928a67365a083886cb85814  ./boot-tools/bootstrap
 
 sha256sum ./boot-tools/transit
-62bb958566c6fde2b2c975eef1c4b8a9d6d5487a9611b97600c1b9d35f8eed9a  ./boot-tools/transit
+d1ef25d67fe339e4ae5bff150fdf814e66dba3e490965d4bb965ed34ea181e03  ./boot-tools/transit
 ```
 
 ### Generating your Node ID


### PR DESCRIPTION
## Description

The encoding used by the tool changed since this example was created. This ensures the example has the same length as those generated by operators following this doc, to prevent confusion.