### PR TITLE
Fix example output of machine account key

### DIFF
--- a/docs/content/node-operation/machine-existing-operator.mdx
+++ b/docs/content/node-operation/machine-existing-operator.mdx
@@ -80,8 +80,7 @@ $tree ./bootstrap/
 You will now need to copy the Machine account public key displayed in the terminal output and head over to [Flow Port](/flow-port/staking-guide/#existing-node-operators) to submit a transaction to create a Machine Account. For example, from the example above, we would copy `0x2743786d1ff1bf7d702...` from this line:
 
 ```shell:title=Example
-<nil> INF machine account public key: 0x2743786d1ff1bf7d7026d693a774210eaa54728343859baab62e2df7f71a370651f4c7fd239d07af170e484eedd4f3c2df47103f6c39baf2eb2a50f67bbcba6a
-```
+<nil> INF encoded machine account public key for entry to Flow Port machineAccountPubKey=f847b84031d9f47b88435e4ea828310529d2c60e806395da50d3dd0dd2f32e2de336fb44eb06488645673850897d7cc017701d7e6272a1ab7f2f125aede46363e973444a02038203e8```
 
 This process will create your machine account for you and show you your machine account's address, which you will need to save for the next step.
 


### PR DESCRIPTION
## Description

Fix an outdated example output from `bootstrap` utility 
