### PR TITLE
Adds local copy of SDK guidelines.

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -96,6 +96,10 @@ const sourceGithubRepos = {
     githubRepo: "onflow/fcl-js",
     // NOTE: path is empty, whole repo is sourced
     path: "docs"
+  },
+  "sdk-guidelines-github": {
+    githubRepo: "onflow/sdks",
+    path: ""
   }
 };
 
@@ -118,6 +122,8 @@ const sourceSlugTransformers = {
   "flow-cli-github": (slug) => slug.replace(/^\/docs\//, "/flow-cli/"),
   "flow-js-testing-github": (slug) =>
     slug.replace(/^\/docs\//, "/flow-js-testing/")
+  // "sdk-guidelines-github": (slug) =>
+  //   slug.replace(/^\/docs\//, "/sdk-guidelines/")
 };
 
 const sources = [
@@ -126,6 +132,15 @@ const sources = [
     options: {
       path: path.join(__dirname, "content"),
       name: "docs"
+    }
+  },
+  {
+    resolve: "gatsby-source-git",
+    options: {
+      name: "sdk-guidelines-github",
+      remote: "https://github.com/onflow/sdks.git",
+      patterns: "**/*.md",
+      local: "content/sdk-guidelines"
     }
   },
   {
@@ -623,6 +638,14 @@ const sections = [
     sidebar: {
       null: ["[Home](/)"],
       FAQ: ["faq/developers", "faq/backers", "faq/operators"]
+    }
+  },
+  {
+    sourceInstanceName: "docs",
+    patterns: ["sdk-guidelines/**/*"],
+    sidebarAlwaysExpanded: true,
+    sidebar: {
+      null: ["[Home](/)"]
     }
   }
 ];


### PR DESCRIPTION
The content is cloned from the guidelines repo, but must exist as part of this repo as well, so. we can customize the docs site menus.