### PR TITLE
Updating flow-rust-sdk location

### DIFF
--- a/docs/content/sdks.mdx
+++ b/docs/content/sdks.mdx
@@ -44,7 +44,7 @@ Want your SDK listed here? Please fork the [`flow` repository](https://github.co
 
 |              |       |                                                                                                                                                |
 | ------------ | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Flow Rust SDK | 🤝😀 | <TrackingLink href="https://github.com/MarshallBelles/flow-rust-sdk" eventName="rust_sdk_selected">https://github.com/MarshallBelles/flow-rust-sdk</TrackingLink> |
+| Flow Rust SDK | 🤝😀[📘](https://docs.rs/flow-rust-sdk/latest/flow_rust_sdk/) | <TrackingLink href="https://crates.io/crates/flow-rust-sdk" eventName="rust_sdk_selected">https://crates.io/crates/flow-rust-sdk</TrackingLink> |
 
 
 ## Python


### PR DESCRIPTION
## Description

Flow-Rust-SDK is now published on crates.io! Updating links.


______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
