### PR TITLE
Redirect old broken FCL docs path

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -470,6 +470,11 @@
       "source": "/dapp-deployment/mainnet-deployment/",
       "destination": "/dapp-development/mainnet-deployment",
       "permanent": true
+    },
+    {
+      "source": "/fcl/flow-app-quickstart/",
+      "destination": "/fcl/tutorials/flow-app-quickstart/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Description

Path changed for FCL Quickstart page in docs and results in "Page Not Found." Redirects old path to new to fix broken link.
