### PR TITLE
Redirect broken deployment doc path

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -452,6 +452,11 @@
       "permanent": true
     },
     {
+      "source": "/dapp-deployment/",
+      "destination": "/dapp-development/deployment",
+      "permanent": true
+    },
+    {
       "source": "/dapp-deployment/contract-testing/",
       "destination": "/dapp-development/contract-testing",
       "permanent": true


### PR DESCRIPTION
## Description

Old deployment link is broken. Redirects to new deployment docs link.
