### PR TITLE
Updating the 'Full Observer Node' page

### DIFF
--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -14,26 +14,26 @@ node for local queries without the need for staking.
 
 ## Running a node
 
-The full observer node was built in collaboration with the [Optakt](https://www.optakt.io/) team.
+The full observer node was built in collaboration with the Optakt team.
 The primary way to run a full observer node is with the Flow Data Provisioning Service (DPS).
 
 ### Data Provisioning Service
 
 The [Data Provisioning Service](https://github.com/optakt/flow-dps/) provides
 efficient access to the full history of Flow blockchain data from a single API.
-The DPS was built by the [Optakt](https://www.optakt.io/) team and greatly streamlines 
+The Flow DPS was built by the [Optakt](https://www.optakt.io/) team and greatly streamlines 
 use cases that require archival data.
-It provides scalable and efficient way to access the history of the Flow execution state,
-both for current live [sporks](/node-operation/spork/) and for past sporks.
+It provides a scalable and efficient way to access the history of the Flow execution state,
+both for current live [sporks](/node-operation/spork/) and for [past sporks](/node-operation/past-sporks).
 
-For more information on the DPS, see their [documentation](https://github.com/optakt/flow-dps/blob/master/README.md).
+For more information on the Flow DPS, see their [documentation](https://github.com/optakt/flow-dps/blob/master/README.md).
 
-The full observer node functionality is provided by the [Flow DPS Live](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live)
+The full observer node functionality is provided by the [Flow DPS live indexer](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live)
 component, which consumes live state updates from the Flow network by acting as a consensus follower.
 
-Flow DPS Live component creates and maintains the DPS index, so that the
-[Flow DPS Server](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-server) can be ran on top of it,
-providing random access to the Flow execution state through its API.
+Once fully synchronized, the Flow DPS live indexer serves the [Flow DPS API](https://github.com/optakt/flow-dps/blob/master/docs/dps-api.md)
+for the active execution state in real time. The [Flow DPS Access API](https://github.com/optakt/flow-dps-access) can be run
+on top of the live indexer to enable use of the data for Access API clients.
 
 ### Custom Implementations
 

--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -19,10 +19,8 @@ The primary way to run a full observer node is with the Flow Data Provisioning S
 
 ### Data Provisioning Service
 
-The [Flow DPS](https://github.com/optakt/flow-dps/) provides efficient access to the full history
-of Flow blockchain data from a single API.
-The Flow DPS was built by the [Optakt](https://www.optakt.io/) team and greatly streamlines 
-use cases that require archival data.
+The [Flow DPS](https://github.com/optakt/flow-dps/) was built by the [Optakt](https://www.optakt.io/) team 
+and greatly streamlines use cases that require archival data.
 It provides a scalable and efficient way to access the history of the Flow execution state,
 both for current live [sporks](/node-operation/spork/) and for [past sporks](/node-operation/past-sporks).
 

--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -14,21 +14,26 @@ node for local queries without the need for staking.
 
 ## Running a node
 
-The full observer node was built in collaboration with the `optakt` team. The
-primary way to run a full observer node is with the Flow Data Provisioning
-Service (DPS).
+The full observer node was built in collaboration with the [Optakt](https://www.optakt.io/) team.
+The primary way to run a full observer node is with the Flow Data Provisioning Service (DPS).
 
 ### Data Provisioning Service
 
 The [Data Provisioning Service](https://github.com/optakt/flow-dps/) provides
-efficient access to the full history of flow blockchain data from a single API.
-DPS was built by the `optakt` team and greatly streamlines use cases that require
-archival data.
+efficient access to the full history of Flow blockchain data from a single API.
+The DPS was built by the [Optakt](https://www.optakt.io/) team and greatly streamlines 
+use cases that require archival data.
+It provides scalable and efficient way to access the history of the Flow execution state,
+both for current live [sporks](/node-operation/spork/) and for past sporks.
 
-For more information on DPS, see their [documentation](https://github.com/optakt/flow-dps/blob/master/docs/introduction.md)
+For more information on the DPS, see their [documentation](https://github.com/optakt/flow-dps/blob/master/README.md).
 
-The full observer node functionality is provided by the [DPS Live](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live)
-component, which consumes live state updates from the flow network.
+The full observer node functionality is provided by the [Flow DPS Live](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live)
+component, which consumes live state updates from the Flow network by acting as a consensus follower.
+
+Flow DPS Live component creates and maintains the DPS index, so that the
+[Flow DPS Server](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-server) can be ran on top of it,
+providing random access to the Flow execution state through its API.
 
 ### Custom Implementations
 

--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -19,8 +19,8 @@ The primary way to run a full observer node is with the Flow Data Provisioning S
 
 ### Data Provisioning Service
 
-The [Data Provisioning Service](https://github.com/optakt/flow-dps/) provides
-efficient access to the full history of Flow blockchain data from a single API.
+The [Flow DPS](https://github.com/optakt/flow-dps/) provides efficient access to the full history
+of Flow blockchain data from a single API.
 The Flow DPS was built by the [Optakt](https://www.optakt.io/) team and greatly streamlines 
 use cases that require archival data.
 It provides a scalable and efficient way to access the history of the Flow execution state,
@@ -28,12 +28,12 @@ both for current live [sporks](/node-operation/spork/) and for [past sporks](/no
 
 For more information on the Flow DPS, see their [documentation](https://github.com/optakt/flow-dps/blob/master/README.md).
 
-The full observer node functionality is provided by the [Flow DPS live indexer](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live)
-component, which consumes live state updates from the Flow network by acting as a consensus follower.
+The full observer node functionality is provided by the [Flow DPS live indexer](https://github.com/optakt/flow-dps/tree/master/cmd/flow-dps-live),
+which consumes live state updates from the Flow network by acting as a consensus follower.
 
 Once fully synchronized, the Flow DPS live indexer serves the [Flow DPS API](https://github.com/optakt/flow-dps/blob/master/docs/dps-api.md)
-for the active execution state in real time. The [Flow DPS Access API](https://github.com/optakt/flow-dps-access) can be run
-on top of the live indexer to enable use of the data for Access API clients.
+for the active execution state in real time.
+The [Flow DPS Access API](https://github.com/optakt/flow-dps-access) can be run on top of the live indexer to enable use of the data for Access API clients.
 
 ### Custom Implementations
 


### PR DESCRIPTION
This PR introduces minor updates to the `Full Observer Node` page.
- fixed link to DPS readme
- fixed usage of the Optakt name, added link to the website
- expanded the description(s)
