### PR TITLE
fix link on "Wallet API Demonstration App"

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -39,7 +39,7 @@ import { IconGithub, IconDiscord, IconDiscourse } from "gatsby-theme-flow/src/ui
     <p>The smart contracts that define the core functionality of the Flow protocol.</p>
   </li>
   <li>
-    <TrackingLink href="https://github.com/onflow/flow-wallet-api-node-demo" eventName="Homepage_link_/flow-wallet-api-node-demo/_clicked">
+    <TrackingLink href="https://github.com/flow-hydraulics/flow-wallet-api/tree/main/examples/nextjs-fusd-provider" eventName="Homepage_link_/flow-wallet-api-node-demo/_clicked">
     Wallet API Demonstration App
     </TrackingLink> <br/>
     <p>A demonstration (written in TypeScript) of a RESTful API that implements a simple custodial wallet service for the Flow blockchain.</p>


### PR DESCRIPTION
## Description

The link on "Wallet API Demonstration App" is pointing to a repo which is archived. This PR updates the link to point to the right page

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
