### PR TITLE
add redirect entries and outdated wallet API link

### DIFF
--- a/docs/content/dapp-development/user-accounts-and-wallets.md
+++ b/docs/content/dapp-development/user-accounts-and-wallets.md
@@ -51,7 +51,7 @@ With that said, there are circumstances where you may want to be a custodian:
 * You are building an dapp on a platform not yet supported by FCL wallets (e.g. mobile, game console).
 * You have business or product needs that necessitate a custodial approach (e.g. fraud protection, users who want a custodial option).
 
-If you do need to build your own wallet, we recommend using the [open-source Wallet API](https://github.com/onflow/wallet-api), a service you can deploy as part of your infrastructure to manage blockchain accounts and keys.
+If you do need to build your own wallet, we recommend using the [open-source Wallet API](https://github.com/flow-hydraulics/flow-wallet-api), a service you can deploy as part of your infrastructure to manage blockchain accounts and keys.
 
 ### Recommendation
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -62,6 +62,11 @@
       "permanent": true
     },
     {
+      "source": "/cadence/index/",
+      "destination": "/cadence/",
+      "permanent": true
+    },
+    {
       "source": "/docs/glossary/",
       "destination": "/intro/glossary/",
       "permanent": true
@@ -484,6 +489,11 @@
     {
       "source": "/fcl/api/",
       "destination": "/fcl",
+      "permanent": true
+    },
+    {
+      "source": "/devtools/emulator/",
+      "destination": "/emulator/",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Description

- As reminded in PR https://github.com/onflow/flow-go-sdk/pull/217/files , /devtools/emulator/ has been removed. adding redirect to avoid 404 errors
- Also add redirect entry to cover bad issue fixed in PR https://github.com/onflow/cadence/pull/1167
- Fix outdated wallet-api link

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
