### PR TITLE
updating related docs to reflect transaction fee changes

### DIFF
--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -168,7 +168,7 @@ Currently NBA Top Shot runs on Mainnet and NBA Top Shot test app runs on Flow Te
 
 ## How much will Gas cost on Flow?
 
-Temporarily, transactions on Flow are free - the node operators are receiving compensation via rewards issued by the network to ensure your transactions are correctly processed. In the future, you may pay a transaction fee yourself but, more likely, the dapp or wallet you’re using will pay those fees for you. Flow supports the ability for someone other than you to pay for your transaction (if you so choose otherwise, you’d acquire FLOW and indeed pay fees). These fees are for spam prevention and will be low and fixed for most transactions.
+Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee of 0.00001 FLOW applied to every transaction submitted to the network. Transaction Fees are subject to change. In the event that a change does occur, the community will be informed ahead of implementation. These fees are for spam prevention and will be low and fixed for all transactions.
 
 ## When will devs be able to deploy on mainnet? How can I create my first account for mainnet?
 

--- a/docs/content/flow-token/concepts.mdx
+++ b/docs/content/flow-token/concepts.mdx
@@ -7,14 +7,10 @@ but here are a few key concepts.
 
 ## Fees
 
-Fees for account creation, and transaction submission will exist in v0.x.x of the testnet.
-
 There are 2 fees that you will see applied to your transactions
 
 - Account Creation: 0.001 FLOW
-- Transaction Fee: 0.000001 FLOW
-
-Please consider the above numbers only as relative reference. The exact values will most likely change during implementation and be dynamically adjusted thereafter.
+- Transaction Fee: 0.00001 FLOW
 
 ### Transaction Fees
 

--- a/docs/content/intro/flow-token.mdx
+++ b/docs/content/intro/flow-token.mdx
@@ -252,12 +252,10 @@ The Flow SDKs also allow polling for events using the Flow Access API,
 
 ## Fees
 
-Fees for account creation, and transaction submission will exist in v0.x.x of the testnet.
-
 There are 2 fees that you will see applied to your transactions
 
-- Account Creation: currently fixed at 0.1 FLOW
-- Transaction Fee: currently fixed at 0.0001 FLOW
+- Account Creation: 0.001 FLOW
+- Transaction Fee: 0.00001 FLOW
 
 ### Transaction Fees
 


### PR DESCRIPTION
## Description
Update related docs to reflect mainnet transaction fee changes announced in https://forum.onflow.org/t/transaction-fee-implementation-10-16-2021/2404
- removing sentences related to testnet version as thats no longer relevant
- update account/transaction fee numbers.  

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
