### PR TITLE
adding a section to the status page to show next mainnet spork announcement

### DIFF
--- a/docs/content/status.mdx
+++ b/docs/content/status.mdx
@@ -4,6 +4,7 @@ title: Flow Network Status
 
 import {
   NetworkStatus,
+  MainnetSpork,
   Announcements
 } from "../plugins/gatsby-theme-flow/src/components/flow-status";
 
@@ -44,6 +45,10 @@ import {
     </>
   )}
 </StatusContext.Consumer>
+
+## Upcoming Mainnet Spork
+
+<MainnetSpork />
 
 ## Announcements
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2386,7 +2386,7 @@
         },
         "unist-util-visit": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
           "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
@@ -2538,7 +2538,7 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.10.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
           "dev": true
         },
@@ -4727,7 +4727,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -4735,7 +4735,7 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
           "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
           "requires": {
             "big.js": "^5.2.2",
@@ -5733,7 +5733,7 @@
       "dependencies": {
         "braces": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
             "fill-range": "^7.0.1"
@@ -5741,7 +5741,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "requires": {
             "to-regex-range": "^5.0.1"
@@ -5749,12 +5749,12 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "requires": {
             "is-number": "^7.0.0"
@@ -6302,7 +6302,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
@@ -6323,7 +6323,7 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
         }
       }
@@ -7488,7 +7488,7 @@
         },
         "tmp": {
           "version": "0.0.33",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
             "os-tmpdir": "~1.0.2"
@@ -8100,7 +8100,7 @@
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "js-yaml": {
@@ -8183,7 +8183,7 @@
         },
         "pkg-dir": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "requires": {
             "find-up": "^2.1.0"
@@ -8235,7 +8235,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -8243,7 +8243,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "pkg-up": {
@@ -8678,7 +8678,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.8.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
           "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
           "requires": {
             "depd": "~1.1.2",
@@ -8690,7 +8690,7 @@
         },
         "raw-body": {
           "version": "2.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
           "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
           "requires": {
             "bytes": "3.1.0",
@@ -8701,7 +8701,7 @@
           "dependencies": {
             "http-errors": {
               "version": "1.7.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
               "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
               "requires": {
                 "depd": "~1.1.2",
@@ -8713,14 +8713,14 @@
             },
             "setprototypeof": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
               "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
             }
           }
         },
         "setprototypeof": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
       }
@@ -9589,7 +9589,7 @@
         },
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "babel-preset-gatsby": {
@@ -9722,7 +9722,7 @@
         },
         "source-map": {
           "version": "0.7.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         },
         "strict-uri-encode": {
@@ -9732,7 +9732,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -9975,7 +9975,7 @@
         },
         "semver": {
           "version": "7.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
         }
       }
@@ -10109,7 +10109,7 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
           "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
           "requires": {
             "big.js": "^5.2.2",
@@ -10119,7 +10119,7 @@
           "dependencies": {
             "json5": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
               "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
               "requires": {
                 "minimist": "^1.2.0"
@@ -10227,7 +10227,7 @@
         },
         "unified": {
           "version": "8.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
           "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
           "requires": {
             "bail": "^1.0.0",
@@ -10244,7 +10244,7 @@
         },
         "unist-util-remove": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
           "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
           "requires": {
             "unist-util-is": "^3.0.0"
@@ -10257,7 +10257,7 @@
         },
         "unist-util-visit": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
           "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
@@ -10533,7 +10533,7 @@
         },
         "mdast-util-compact": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
           "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
           "requires": {
             "unist-util-visit": "^2.0.0"
@@ -10567,7 +10567,7 @@
         },
         "remark-stringify": {
           "version": "8.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
           "integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
           "requires": {
             "ccount": "^1.0.0",
@@ -10596,7 +10596,7 @@
         },
         "unified": {
           "version": "8.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
           "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
           "requires": {
             "bail": "^1.0.0",
@@ -10715,7 +10715,7 @@
         },
         "unist-util-visit": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
           "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
@@ -11172,23 +11172,13 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
             "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
             "convert-source-map": "^1.5.1",
             "debug": "^2.6.9",
             "json5": "^0.5.1",
             "lodash": "^4.17.4",
             "minimatch": "^3.0.4",
             "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
           },
@@ -11227,7 +11217,6 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
           "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
           "requires": {
-            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
             "find-up": "^2.1.0",
             "istanbul-lib-instrument": "^1.10.1",
             "test-exclude": "^4.2.1"
@@ -11243,8 +11232,7 @@
           "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
           "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
           "requires": {
-            "babel-plugin-jest-hoist": "^22.4.4",
-            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+            "babel-plugin-jest-hoist": "^22.4.4"
           }
         },
         "braces": {
@@ -11252,8 +11240,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
             "repeat-element": "^1.1.2"
           }
         },
@@ -11360,7 +11346,6 @@
               "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
               "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
               "requires": {
-                "lodash.sortby": "^4.7.0",
                 "tr46": "^1.0.1",
                 "webidl-conversions": "^4.0.2"
               }
@@ -11427,18 +11412,12 @@
         "exec-sh": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-          "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-          "requires": {
-            "merge": "^1.2.0"
-          }
+          "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw=="
         },
         "expand-brackets": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
         },
         "expect": {
           "version": "22.4.3",
@@ -11573,11 +11552,6 @@
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
           "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
           "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
             "istanbul-lib-coverage": "^1.2.1",
             "semver": "^5.3.0"
           }
@@ -11630,7 +11604,6 @@
             "graceful-fs": "^4.1.11",
             "import-local": "^1.0.0",
             "is-ci": "^1.0.10",
-            "istanbul-api": "^1.1.14",
             "istanbul-lib-coverage": "^1.1.1",
             "istanbul-lib-instrument": "^1.8.0",
             "istanbul-lib-source-maps": "^1.2.1",
@@ -11650,7 +11623,6 @@
             "jest-worker": "^22.2.2",
             "micromatch": "^2.3.11",
             "node-notifier": "^5.2.1",
-            "realpath-native": "^1.0.0",
             "rimraf": "^2.5.4",
             "slash": "^1.0.0",
             "string-length": "^2.0.0",
@@ -11797,7 +11769,6 @@
           "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
           "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
           "requires": {
-            "browser-resolve": "^1.11.2",
             "chalk": "^2.0.1"
           }
         },
@@ -11845,9 +11816,7 @@
             "jest-resolve": "^22.4.2",
             "jest-util": "^22.4.1",
             "jest-validate": "^22.4.4",
-            "json-stable-stringify": "^1.0.1",
             "micromatch": "^2.3.11",
-            "realpath-native": "^1.0.0",
             "slash": "^1.0.0",
             "strip-bom": "3.0.0",
             "write-file-atomic": "^2.1.0",
@@ -11914,19 +11883,14 @@
             "abab": "^2.0.0",
             "acorn": "^5.5.3",
             "acorn-globals": "^4.1.0",
-            "array-equal": "^1.0.0",
             "cssom": ">= 0.3.2 < 0.4.0",
             "cssstyle": "^1.0.0",
             "data-urls": "^1.0.0",
             "domexception": "^1.0.1",
             "escodegen": "^1.9.1",
             "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.3.0",
             "nwsapi": "^2.0.7",
             "parse5": "4.0.0",
-            "pn": "^1.1.0",
-            "request": "^2.87.0",
-            "request-promise-native": "^1.0.5",
             "sax": "^1.2.4",
             "symbol-tree": "^3.2.2",
             "tough-cookie": "^2.3.4",
@@ -11981,10 +11945,7 @@
             "strip-bom": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "requires": {
-                "is-utf8": "^0.2.0"
-              }
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
             }
           }
         },
@@ -12015,14 +11976,10 @@
             "braces": "^1.8.2",
             "expand-brackets": "^0.1.4",
             "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
             "is-extglob": "^1.0.0",
             "is-glob": "^2.0.1",
             "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "normalize-path": "^2.0.1"
           }
         },
         "node-notifier": {
@@ -12030,10 +11987,8 @@
           "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
           "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
           "requires": {
-            "growly": "^1.3.0",
             "is-wsl": "^1.1.0",
             "semver": "^5.5.0",
-            "shellwords": "^0.1.1",
             "which": "^1.3.0"
           }
         },
@@ -12181,8 +12136,7 @@
             "fsevents": "^1.2.3",
             "micromatch": "^3.1.4",
             "minimist": "^1.1.1",
-            "walker": "~1.0.5",
-            "watch": "~0.18.0"
+            "walker": "~1.0.5"
           },
           "dependencies": {
             "arr-diff": {
@@ -12443,7 +12397,6 @@
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
           "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
           "requires": {
-            "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
           }
@@ -12465,17 +12418,13 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
             },
             "string-width": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
               }
@@ -12522,7 +12471,6 @@
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -14722,7 +14670,7 @@
       "dependencies": {
         "detect-newline": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
           "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
           "dev": true
         }
@@ -15010,7 +14958,7 @@
         },
         "strip-bom": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
           "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
           "dev": true
         }
@@ -15116,7 +15064,7 @@
       "dependencies": {
         "camelcase": {
           "version": "6.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
           "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         }
@@ -15480,7 +15428,7 @@
       "dependencies": {
         "mime": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "optional": true
         },
@@ -16637,7 +16585,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -17841,7 +17789,7 @@
       "dependencies": {
         "is-wsl": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
           "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         }
       }
@@ -18471,7 +18419,7 @@
       "dependencies": {
         "async": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
             "lodash": "^4.17.14"
@@ -19709,7 +19657,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -20955,7 +20903,7 @@
         },
         "htmlparser2": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
           "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
           "requires": {
             "domelementtype": "^2.0.1",
@@ -23467,7 +23415,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.7.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
@@ -23829,7 +23777,7 @@
         },
         "array-union": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "requires": {
             "array-uniq": "^1.0.1"
@@ -23842,7 +23790,7 @@
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "requires": {
             "anymatch": "^2.0.0",
@@ -23861,7 +23809,7 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "requires": {
             "string-width": "^3.1.0",
@@ -23876,7 +23824,7 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -23908,7 +23856,7 @@
         },
         "del": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
           "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
           "requires": {
             "@types/glob": "^7.1.1",
@@ -23922,7 +23870,7 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "extend-shallow": {
@@ -23973,7 +23921,7 @@
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -23985,7 +23933,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -24067,7 +24015,7 @@
         },
         "p-map": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         },
         "p-try": {
@@ -24113,7 +24061,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "requires": {
             "ajv": "^6.1.0",
@@ -24123,7 +24071,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -24138,7 +24086,7 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -24156,7 +24104,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -24176,7 +24124,7 @@
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -24191,7 +24139,7 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -24209,7 +24157,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "requires": {
             "cliui": "^5.0.0",
@@ -24226,7 +24174,7 @@
         },
         "yargs-parser": {
           "version": "13.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "requires": {
             "camelcase": "^5.0.0",
@@ -24603,7 +24551,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
@@ -24649,7 +24597,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"

--- a/docs/plugins/gatsby-theme-flow/src/components/flow-status/constants.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/flow-status/constants.js
@@ -13,6 +13,8 @@ export const STATUSPAGE_API_URL =
   "https://api.statuspage.io/v1/pages/ytw5bdg6zr13/components";
 export const BREAKING_CHANGES_RESOURCE =
   "https://forum.onflow.org/c/announcements/breaking-changes/30.json";
+export const MAINNET_SPORK =
+    "https://forum.onflow.org/c/mainnet-sporks/36.json";
 
 export const statusPageStatuses = {
   operational: HEALTHY,

--- a/docs/plugins/gatsby-theme-flow/src/components/flow-status/index.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/flow-status/index.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { StatusCard, RecentPost } from "./components";
 import { useBreakingChangesPosts } from "./hooks";
-import { StatusWrapper, AnnouncementsWrapper } from "./styles";
+import { useMainnetSporkPosts } from "./hooks";
+import { StatusWrapper, MainnetSporkWrapper, AnnouncementsWrapper } from "./styles";
 
 export function NetworkStatus(props) {
   return (
@@ -19,5 +20,16 @@ export function Announcements() {
         <RecentPost key={post.id} post={post} />
       ))}
     </AnnouncementsWrapper>
+  );
+}
+
+export function MainnetSpork() {
+  const mainnetSporkPosts = useMainnetSporkPosts();
+  return (
+      <MainnetSporkWrapper>
+        {mainnetSporkPosts.map((post) => (
+            <RecentPost key={post.id} post={post} />
+        ))}
+      </MainnetSporkWrapper>
   );
 }

--- a/docs/plugins/gatsby-theme-flow/src/components/flow-status/styles.js
+++ b/docs/plugins/gatsby-theme-flow/src/components/flow-status/styles.js
@@ -7,6 +7,7 @@ import breakpoints from "../../utils/breakpoints";
 import { HEALTHY, UNAVAILABLE } from "./constants";
 
 export const StatusWrapper = styled.div({});
+export const MainnetSporkWrapper = styled.div({});
 export const AnnouncementsWrapper = styled.div({});
 
 function getColor(status) {


### PR DESCRIPTION
The next mainnet spork announcement needs to be displayed explicitly on the status page. 
To keep it from scrolling out in case there are other announcements after the mainnet announcement, I have added a new section for the mainnet spork announcement (@10thfloor correspondingly created a new `mainnet-spork` category on the forum - https://forum.onflow.org/c/mainnet-sporks/36).

I have made the change to add this new section

![Screen Shot 2021-11-22 at 5 22 28 PM](https://user-images.githubusercontent.com/1117327/142958520-028b645f-2bbe-432e-a37c-bc783675bfcb.png)


## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
