### PR TITLE
Vishal/more openapi changes

### DIFF
--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -479,11 +479,11 @@ components:
           items:
             $ref: '#/components/schemas/Transaction'
         _expandable:
-          type: array
-          items:
-            type: object
-            properties:
-              transaction:
+          type: object
+          properties:
+            transactions:
+              type: array
+              items:
                 type: string
                 format: uri
         _links:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -27,7 +27,6 @@ paths:
             uniqueItems: true
           explode: false
           style: form
-          required: true
         - name: start_height
           in: query
           schema:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -478,6 +478,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Transaction'
+        _expandable:
+          type: array
+          items:
+            type: object
+            properties:
+              transaction:
+                type: string
+                format: uri
         _links:
           $ref: '#/components/schemas/Links'
     Transaction:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -408,9 +408,6 @@ components:
   schemas:
     Account:
       type: object
-      required:
-        - address
-        - balance
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -439,14 +436,6 @@ components:
           $ref: '#/components/schemas/Links'
     AccountPublicKey:
       type: object
-      required:
-        - index
-        - public_key
-        - signing_algorithm
-        - hashing_algorithm
-        - sequence_number
-        - weight
-        - revoked
       properties:
         index:
           type: integer
@@ -482,9 +471,6 @@ components:
         - KMAC128
     Collection:
       type: object
-      required:
-        - id
-        - transactions
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -496,17 +482,6 @@ components:
           $ref: '#/components/schemas/Links'
     Transaction:
       type: object
-      required:
-        - id
-        - script
-        - arguments
-        - reference_block_id
-        - gas_limit
-        - payer
-        - proposal_key
-        - authorizers
-        - payload_signatures
-        - envelope_signatures
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -551,10 +526,6 @@ components:
           $ref: '#/components/schemas/Links'
     ProposalKey:
       type: object
-      required:
-        - address
-        - key_index
-        - sequence_number
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -566,11 +537,6 @@ components:
           format: uint64
     TransactionSignature:
       type: object
-      required:
-        - address
-        - signer_index
-        - key_index
-        - signature
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -584,12 +550,6 @@ components:
           $ref: '#/components/schemas/Signature'
     TransactionResult:
       type: object
-      required:
-        - block_id
-        - status
-        - error_message
-        - computation_used
-        - events
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -616,8 +576,6 @@ components:
        - Expired
     Block:
       type: object
-      required:
-        - header
       properties:
         header:
           $ref: '#/components/schemas/BlockHeader'
@@ -637,12 +595,6 @@ components:
           $ref: '#/components/schemas/Links'
     BlockHeader:
       type: object
-      required:
-        - id
-        - parent_id
-        - height
-        - timestamp
-        - parent_voter_signature
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -658,9 +610,6 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockPayload:
       type: object
-      required:
-        - collection_guarantees
-        - block_seals
       properties:
         collection_guarantees:
           type: array
@@ -674,10 +623,6 @@ components:
           uniqueItems: true
     CollectionGuarantee:
       type: object
-      required:
-        - collection_id
-        - signer_ids
-        - signature
       properties:
         collection_id:
           $ref: '#/components/schemas/Identifier'
@@ -691,11 +636,6 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockSeal:
       type: object
-      required:
-        - block_id
-        - result_id
-        - final_state
-        - aggregated_approval_signatures
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -716,9 +656,6 @@ components:
       pattern: '[a-fA-F0-9]{64}'
     AggregatedSignature:
       type: object
-      required:
-        - verifier_signatures
-        - signer_ids
       properties:
         verifier_signatures:
           type: array
@@ -734,10 +671,6 @@ components:
           uniqueItems: true
     ExecutionResult:
       type: object
-      required:
-        - id
-        - block_id
-        - events
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -751,12 +684,6 @@ components:
           $ref: '#/components/schemas/Links'
     Event:
       type: object
-      required:
-        - type
-        - transaction_id
-        - transaction_index
-        - event_index
-        - payload
       properties:
         type:
           $ref: '#/components/schemas/EventType'


### PR DESCRIPTION
1. Removing `height` as require for the Get Block by height call since height can be absent if `start_height` and `end_height `query params are specified. 2374431dace71bd22901b6d7becd9a14375ef26e
2. The `select` query param lets you unselect any field in the response hence removing all the `require` for elements in the response object. 9a99bbf
3. For the GetCollection by ID call, it will be expensive to look up all the transactions for the collection and the response could be huge. So made a change to make the transaction in the response as `expandable`. If the query param specifies `?expand=transaction` only then will the transactions be looked up and populated in the response, otherwise the `_expandable` field will list all the links (e.g. /v1/transactions/1234556999999) in an array thus skipping the extra lookups for transaction. 93d7a6d

Once y'all approve the PR, I will also include the generated files :) 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
