### PR TITLE
reverting removal require fields

### DIFF
--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -440,6 +440,14 @@ components:
           $ref: '#/components/schemas/Links'
     AccountPublicKey:
       type: object
+      required:
+        - index
+        - public_key
+        - signing_algorithm
+        - hashing_algorithm
+        - sequence_number
+        - weight
+        - revoked
       properties:
         index:
           type: integer
@@ -553,6 +561,10 @@ components:
           $ref: '#/components/schemas/Links'
     ProposalKey:
       type: object
+      required:
+        - address
+        - key_index
+        - sequence_number
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -564,6 +576,11 @@ components:
           format: uint64
     TransactionSignature:
       type: object
+      required:
+        - address
+        - signer_index
+        - key_index
+        - signature
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -577,6 +594,12 @@ components:
           $ref: '#/components/schemas/Signature'
     TransactionResult:
       type: object
+      required:
+        - block_id
+        - status
+        - error_message
+        - computation_used
+        - events
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -625,6 +648,12 @@ components:
           $ref: '#/components/schemas/Links'
     BlockHeader:
       type: object
+      required:
+        - id
+        - parent_id
+        - height
+        - timestamp
+        - parent_voter_signature
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -640,6 +669,9 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockPayload:
       type: object
+      required:
+        - collection_guarantees
+        - block_seals
       properties:
         collection_guarantees:
           type: array
@@ -653,6 +685,10 @@ components:
           uniqueItems: true
     CollectionGuarantee:
       type: object
+      required:
+        - collection_id
+        - signer_ids
+        - signature
       properties:
         collection_id:
           $ref: '#/components/schemas/Identifier'
@@ -666,6 +702,11 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockSeal:
       type: object
+      required:
+        - block_id
+        - result_id
+        - final_state
+        - aggregated_approval_signatures
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -686,6 +727,9 @@ components:
       pattern: '[a-fA-F0-9]{64}'
     AggregatedSignature:
       type: object
+      required:
+        - verifier_signatures
+        - signer_ids
       properties:
         verifier_signatures:
           type: array
@@ -701,6 +745,10 @@ components:
           uniqueItems: true
     ExecutionResult:
       type: object
+      required:
+        - id
+        - block_id
+        - events
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -714,6 +762,12 @@ components:
           $ref: '#/components/schemas/Links'
     Event:
       type: object
+      required:
+        - type
+        - transaction_id
+        - transaction_index
+        - event_index
+        - payload
       properties:
         type:
           $ref: '#/components/schemas/EventType'

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -479,11 +479,11 @@ components:
           items:
             $ref: '#/components/schemas/Transaction'
         _expandable:
-          type: array
-          items:
-            type: object
-            properties:
-              transaction:
+          type: object
+          properties:
+            transactions:
+              type: array
+              items:
                 type: string
                 format: uri
         _links:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -179,7 +179,7 @@ paths:
                 reference_block_id:
                   $ref: '#/components/schemas/Identifier'
                 gas_limit:
-                  type: integer
+                  type: string
                   format: uint64
                 payer:
                   $ref: '#/components/schemas/Address'
@@ -416,7 +416,7 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         balance:
-          type: integer
+          type: string
           format: uint64
         keys:
           type: array
@@ -450,7 +450,7 @@ components:
         - revoked
       properties:
         index:
-          type: integer
+          type: string
           format: uint64
         public_key:
           type: string
@@ -460,10 +460,10 @@ components:
         hashing_algorithm:
           $ref: '#/components/schemas/HashingAlgorithm'
         sequence_number:
-          type: integer
+          type: string
           format: uint64
         weight:
-          type: integer
+          type: string
           format: uint64
         revoked:
           type: boolean
@@ -531,7 +531,7 @@ components:
         reference_block_id:
           $ref: '#/components/schemas/Identifier'
         gas_limit:
-          type: integer
+          type: string
           format: uint64
         payer:
           $ref: '#/components/schemas/Address'
@@ -569,10 +569,10 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         key_index:
-          type: integer
+          type: string
           format: uint64
         sequence_number:
-          type: integer
+          type: string
           format: uint64
     TransactionSignature:
       type: object
@@ -585,10 +585,10 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         signer_index:
-          type: integer
+          type: string
           format: uint64
         key_index:
-          type: integer
+          type: string
           format: uint64
         signature:
           $ref: '#/components/schemas/Signature'
@@ -608,7 +608,7 @@ components:
         error_message:
           type: string
         computation_used:
-          type: integer
+          type: string
           format: uint64
         events:
           type: array
@@ -660,7 +660,7 @@ components:
         parent_id:
           $ref: '#/components/schemas/Identifier'
         height:
-          type: integer
+          type: string
           format: uint64
         timestamp:
           type: string
@@ -774,17 +774,17 @@ components:
         transaction_id:
           $ref: '#/components/schemas/Identifier'
         transaction_index:
-          type: integer
+          type: string
           format: uint64
         event_index:
-          type: integer
+          type: string
           format: uint64
         payload:
           type: string
           format: byte
     BlockHeight:
       oneOf:
-        - type: integer
+        - type: string
           format: uint64
         - type: string
           enum:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -408,6 +408,9 @@ components:
   schemas:
     Account:
       type: object
+      required:
+        - address
+        - balance
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -436,6 +439,14 @@ components:
           $ref: '#/components/schemas/Links'
     AccountPublicKey:
       type: object
+      required:
+        - index
+        - public_key
+        - signing_algorithm
+        - hashing_algorithm
+        - sequence_number
+        - weight
+        - revoked
       properties:
         index:
           type: integer
@@ -471,6 +482,9 @@ components:
         - KMAC128
     Collection:
       type: object
+      required:
+        - id
+        - transactions
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -490,6 +504,17 @@ components:
           $ref: '#/components/schemas/Links'
     Transaction:
       type: object
+      required:
+        - id
+        - script
+        - arguments
+        - reference_block_id
+        - gas_limit
+        - payer
+        - proposal_key
+        - authorizers
+        - payload_signatures
+        - envelope_signatures
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -534,6 +559,10 @@ components:
           $ref: '#/components/schemas/Links'
     ProposalKey:
       type: object
+      required:
+        - address
+        - key_index
+        - sequence_number
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -545,6 +574,11 @@ components:
           format: uint64
     TransactionSignature:
       type: object
+      required:
+        - address
+        - signer_index
+        - key_index
+        - signature
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -558,6 +592,12 @@ components:
           $ref: '#/components/schemas/Signature'
     TransactionResult:
       type: object
+      required:
+        - block_id
+        - status
+        - error_message
+        - computation_used
+        - events
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -584,6 +624,8 @@ components:
        - Expired
     Block:
       type: object
+      required:
+        - header
       properties:
         header:
           $ref: '#/components/schemas/BlockHeader'
@@ -603,6 +645,12 @@ components:
           $ref: '#/components/schemas/Links'
     BlockHeader:
       type: object
+      required:
+        - id
+        - parent_id
+        - height
+        - timestamp
+        - parent_voter_signature
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -618,6 +666,9 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockPayload:
       type: object
+      required:
+        - collection_guarantees
+        - block_seals
       properties:
         collection_guarantees:
           type: array
@@ -631,6 +682,10 @@ components:
           uniqueItems: true
     CollectionGuarantee:
       type: object
+      required:
+        - collection_id
+        - signer_ids
+        - signature
       properties:
         collection_id:
           $ref: '#/components/schemas/Identifier'
@@ -644,6 +699,11 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockSeal:
       type: object
+      required:
+        - block_id
+        - result_id
+        - final_state
+        - aggregated_approval_signatures
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -664,6 +724,9 @@ components:
       pattern: '[a-fA-F0-9]{64}'
     AggregatedSignature:
       type: object
+      required:
+        - verifier_signatures
+        - signer_ids
       properties:
         verifier_signatures:
           type: array
@@ -679,6 +742,10 @@ components:
           uniqueItems: true
     ExecutionResult:
       type: object
+      required:
+        - id
+        - block_id
+        - events
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -692,6 +759,12 @@ components:
           $ref: '#/components/schemas/Links'
     Event:
       type: object
+      required:
+        - type
+        - transaction_id
+        - transaction_index
+        - event_index
+        - payload
       properties:
         type:
           $ref: '#/components/schemas/EventType'

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -477,7 +477,6 @@ components:
       type: object
       required:
         - id
-        - transactions
         - _expandable
       properties:
         id:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -27,7 +27,6 @@ paths:
             uniqueItems: true
           explode: false
           style: form
-          required: true
         - name: start_height
           in: query
           schema:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -411,6 +411,7 @@ components:
       required:
         - address
         - balance
+        - _expandable
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -485,6 +486,7 @@ components:
       required:
         - id
         - transactions
+        - _expandable
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -515,6 +517,7 @@ components:
         - authorizers
         - payload_signatures
         - envelope_signatures
+        - _expandable
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -626,6 +629,7 @@ components:
       type: object
       required:
         - header
+        - _expandable
       properties:
         header:
           $ref: '#/components/schemas/BlockHeader'

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -478,6 +478,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Transaction'
+        _expandable:
+          type: array
+          items:
+            type: object
+            properties:
+              transaction:
+                type: string
+                format: uri
         _links:
           $ref: '#/components/schemas/Links'
     Transaction:

--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -408,9 +408,6 @@ components:
   schemas:
     Account:
       type: object
-      required:
-        - address
-        - balance
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -439,14 +436,6 @@ components:
           $ref: '#/components/schemas/Links'
     AccountPublicKey:
       type: object
-      required:
-        - index
-        - public_key
-        - signing_algorithm
-        - hashing_algorithm
-        - sequence_number
-        - weight
-        - revoked
       properties:
         index:
           type: integer
@@ -482,9 +471,6 @@ components:
         - KMAC128
     Collection:
       type: object
-      required:
-        - id
-        - transactions
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -496,17 +482,6 @@ components:
           $ref: '#/components/schemas/Links'
     Transaction:
       type: object
-      required:
-        - id
-        - script
-        - arguments
-        - reference_block_id
-        - gas_limit
-        - payer
-        - proposal_key
-        - authorizers
-        - payload_signatures
-        - envelope_signatures
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -551,10 +526,6 @@ components:
           $ref: '#/components/schemas/Links'
     ProposalKey:
       type: object
-      required:
-        - address
-        - key_index
-        - sequence_number
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -566,11 +537,6 @@ components:
           format: uint64
     TransactionSignature:
       type: object
-      required:
-        - address
-        - signer_index
-        - key_index
-        - signature
       properties:
         address:
           $ref: '#/components/schemas/Address'
@@ -584,12 +550,6 @@ components:
           $ref: '#/components/schemas/Signature'
     TransactionResult:
       type: object
-      required:
-        - block_id
-        - status
-        - error_message
-        - computation_used
-        - events
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -616,8 +576,6 @@ components:
        - Expired
     Block:
       type: object
-      required:
-        - header
       properties:
         header:
           $ref: '#/components/schemas/BlockHeader'
@@ -637,12 +595,6 @@ components:
           $ref: '#/components/schemas/Links'
     BlockHeader:
       type: object
-      required:
-        - id
-        - parent_id
-        - height
-        - timestamp
-        - parent_voter_signature
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -658,9 +610,6 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockPayload:
       type: object
-      required:
-        - collection_guarantees
-        - block_seals
       properties:
         collection_guarantees:
           type: array
@@ -674,10 +623,6 @@ components:
           uniqueItems: true
     CollectionGuarantee:
       type: object
-      required:
-        - collection_id
-        - signer_ids
-        - signature
       properties:
         collection_id:
           $ref: '#/components/schemas/Identifier'
@@ -691,11 +636,6 @@ components:
           $ref: '#/components/schemas/Signature'
     BlockSeal:
       type: object
-      required:
-        - block_id
-        - result_id
-        - final_state
-        - aggregated_approval_signatures
       properties:
         block_id:
           $ref: '#/components/schemas/Identifier'
@@ -716,9 +656,6 @@ components:
       pattern: '[a-fA-F0-9]{64}'
     AggregatedSignature:
       type: object
-      required:
-        - verifier_signatures
-        - signer_ids
       properties:
         verifier_signatures:
           type: array
@@ -734,10 +671,6 @@ components:
           uniqueItems: true
     ExecutionResult:
       type: object
-      required:
-        - id
-        - block_id
-        - events
       properties:
         id:
           $ref: '#/components/schemas/Identifier'
@@ -751,12 +684,6 @@ components:
           $ref: '#/components/schemas/Links'
     Event:
       type: object
-      required:
-        - type
-        - transaction_id
-        - transaction_index
-        - event_index
-        - payload
       properties:
         type:
           $ref: '#/components/schemas/EventType'


### PR DESCRIPTION
1. In my last [PR](https://github.com/onflow/flow/pull/705) I [removed](9a99bbf) the required fields from the response. However, this has a consequence of adding the `omitempty` tag for all these fields in the generated model. This results in these fields being skipped all together if not set e.g. if the `revoked` feild of the key is `false` it is not included in the response.

I could change the generated model to remove those tags but I am trying to keep the generated model as-is as much as possible.
Hence, re-introducing the required field. The onus will now be on the client to know that if a select was specified, these required fields will be skipped from the response even through they are required.

2. Changing all `uint64` integer to be of type `string` instead.

3. Finally, I noticed the [examples](https://www.notion.so/dapperlabs/REST-API-Design-9594c690c8a342e383e1d372b5860116#ff2ec5c8469748ac859b60d195ae23ac) have `"_expandable": {},`, so marking `_expandable` as require too to be always included in the response.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
