### PR TITLE
correct key weight document to be in the range of [1, 1000]

### DIFF
--- a/docs/content/concepts/accounts-and-keys.md
+++ b/docs/content/concepts/accounts-and-keys.md
@@ -224,7 +224,7 @@ Since the proposal key must always have a valid signature, this scenario is only
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
+| `0x01`  | 1      | 1000   |
 
 ```javascript
 {
@@ -254,8 +254,8 @@ A transaction that declares a single account as the proposer, payer and authoriz
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
 
 ```javascript
 {
@@ -290,8 +290,8 @@ A transaction that declares different accounts for each signing role will requir
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
-| `0x02`  | 1      | 1.0    |
+| `0x01`  | 1      | 1000   |
+| `0x02`  | 1      | 1000   |
 
 ```javascript
 {
@@ -327,10 +327,10 @@ A transaction that declares different accounts for each signing role may require
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
-| `0x02`  | 1      | 0.5    |
-| `0x02`  | 2      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
+| `0x02`  | 1      | 500    |
+| `0x02`  | 2      | 500    |
 
 ```javascript
 {

--- a/docs/content/concepts/transaction-signing.md
+++ b/docs/content/concepts/transaction-signing.md
@@ -139,7 +139,7 @@ with full signing weight.
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
+| `0x01`    | 1      | 1000   |
 
 ```javascript
 {	
@@ -171,8 +171,8 @@ uses weighted keys to achieve multi-sig functionality.
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
 
 ```javascript
 {	
@@ -208,8 +208,8 @@ require at least one signature from each account.
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
-| `0x02`    | 1      | 1.0    |
+| `0x01`    | 1      | 1000   |
+| `0x02`    | 1      | 1000   |
 
 ```javascript
 {	
@@ -247,10 +247,10 @@ use weighted keys to achieve multi-sig functionality.
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
-| `0x02`    | 1      | 0.5    |
-| `0x02`    | 2      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
+| `0x02`    | 1      | 500    |
+| `0x02`    | 2      | 500    |
 
 ```javascript
 {	


### PR DESCRIPTION
Closes: #473 

## Description

Some documents are using 0.1 and 1.0 as key weight, which should be in the range of [1, 1000]

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
