### PR TITLE
Adding new Glossary page to doc sidebar

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -645,7 +645,8 @@ const sections = [
         "docs/language/built-in-functions",
         "docs/language/environment-information",
         "docs/language/crypto",
-        "docs/language/type-hierarchy"
+        "docs/language/type-hierarchy",
+        "docs/language/glossary"
       ]
     }
   },


### PR DESCRIPTION
Partly addresses [onflow/cadence/issues/959](https://github.com/onflow/cadence/issues/959)

## Description

Adding new Cadence Glossary page to sidebar. For more context, discussion and commit history see [https://github.com/onflow/cadence/pull/1279](https://github.com/onflow/cadence/pull/1279)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
