### PR TITLE
address navigation issues in Cadence and JS testing library

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -321,15 +321,15 @@ const sections = [
       Overview: ["[Cadence Language Reference](/cadence/language/)"],
       "Developer Guides": [
         "[Introduction to Cadence](/cadence/)",
-        "docs/design-patterns",
-        "docs/contract-upgrades",
-        "docs/anti-patterns",
-        "docs/msg-sender",
-        "docs/measuring-time",
-        "docs/subtyping",
-        "docs/migration-guide",
-        "docs/json-cadence-spec",
-        "docs/syntax-highlighting"
+        "[Cadence Design Patterns](/cadence/design-patterns/)",
+        "[Contract Upgrades with Incompatible Changes](/cadence/contract-upgrades/)",
+        "[Cadence Anti-Patterns](/cadence/anti-patterns/)",
+        "[msg․sender Considered Harmful](/cadence/msg-sender/)",
+        "[Measuring Time In Cadence](/cadence/measuring-time/)",
+        "[Subtyping](/cadence/subtyping/)",
+        "[Migration Guide](/cadence/migration-guide/)",
+        "[JSON-Cadence Data Interchange Format](/cadence/json-cadence-spec/)",
+        "[Syntax Highlighting](/cadence/syntax-highlighting/)"
       ],
       Tutorial: [
         "docs/tutorial/01-first-steps",
@@ -475,21 +475,23 @@ const sections = [
     sidebarAlwaysExpanded: true,
     sidebar: {
       null: ["[Home](/)"],
-      Overview: ["docs/api", "docs/examples"],
+      Overview: [
+        "[API](/flow-js-testing/api/)"
+      ],
       Guides: [
-        "docs/install",
-        "docs/init",
-        "docs/accounts",
-        "docs/contracts",
-        "docs/emulator",
-        "docs/execute-scripts",
-        "docs/flow-token",
-        "docs/generator",
-        "docs/jest-helpers",
-        "docs/send-transactions",
-        "docs/structure",
-        "docs/templates",
-        "docs/type"
+        "[Install Flow Javascript Testing Framework](/flow-js-testing/install/)",
+        "[Init](/flow-js-testing/init)",
+        "[Accounts](/flow-js-testing/accounts/)",
+        "[Contracts](/flow-js-testing/contracts/)",
+        "[Emulator](/flow-js-testing/emulator/)",
+        "[Execute Scripts](/flow-js-testing/execute-scripts/)",
+        "[FLOW Token](/flow-js-testing/flow-token/)",
+        "[Bootstrap Framework](/flow-js-testing/generator)",
+        "[Jest Helpers](/flow-js-testing/jest-helpers/)",
+        "[Send Transactions](/flow-js-testing/send-transactions/)",
+        "[Folder Structure](/flow-js-testing/structure)",
+        "[Templates](/flow-js-testing/templates/)",
+        "[Types](/flow-js-testing/types/)"
       ]
     }
   },


### PR DESCRIPTION
Navigation sidebar is broken for both Cadence and JS testing library documents. It turns out that some .md files are missing a `#1` header or a title , which breaks the navigation bar. 
This change explicitly pins the title for each item in the navigation bar to solve this issue. This change also uses absolute doc site path (i.e. /flow-js-testing/acconts/) rather than the pre-transformed path (i.e. docs/accounts) to make the config a bit clear

## Tests
verified locally that the navigation bar works. 

### Cadence navigation before (and "next" link is missing): 
![Screen Shot 2021-12-16 at 6 01 43 PM](https://user-images.githubusercontent.com/91617737/146473003-4b2469ae-2f71-4754-8844-9971af56b53d.png)

### cadence navigation after: 
![Screen Shot 2021-12-16 at 7 46 03 PM](https://user-images.githubusercontent.com/91617737/146473043-588e9375-da1a-45fd-a213-eeea81a5a041.png)


### js-testing library before:
The overview section is blank + the navigation link is broken + the "types" section is missing:
![Screen Shot 2021-12-16 at 8 22 33 PM](https://user-images.githubusercontent.com/91617737/146473239-b0da6533-64d4-4539-9a63-8101e5f55565.png)

### js-testing library after: 

![Screen Shot 2021-12-16 at 8 01 55 PM](https://user-images.githubusercontent.com/91617737/146473252-486f3863-16cb-4107-9a92-f490f8823fe4.png)

______

For contributor use:

- [c] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [c] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
