### PR TITLE
Fix dead link to Ledger Live installation guide

### DIFF
--- a/docs/content/flow-token/available-wallets.md
+++ b/docs/content/flow-token/available-wallets.md
@@ -51,7 +51,7 @@ You can create a Blocto account to hold FLOW in 2 different ways:
 
 1.  Ensure you have:
 
-- a.) [Ledger Live](https://support.ledger.com/hc/en-us/articles/360006395553) installed on your computer.
+- a.) [Ledger Live](https://support.ledger.com/hc/en-us/articles/4404389606417-Download-and-install-Ledger-Live?docs=true) installed on your computer.
 
 - b.) [Initialize](https://support.ledger.com/hc/en-us/articles/360000613793) your Ledger Device.
 


### PR DESCRIPTION
Closes topic raised on forum: https://forum.onflow.org/t/dead-ledger-live-link/2607

## Description

Fixes dead link pointing to how to install Ledger Live in the Available Wallet docs page.
https://docs.onflow.org/flow-token/available-wallets/

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels `no, don't have permission`
