### PR TITLE
patch: fix in epoch timings

### DIFF
--- a/docs/content/staking/schedule.mdx
+++ b/docs/content/staking/schedule.mdx
@@ -32,8 +32,8 @@ The exact timing of the epoch end is influenced by the number of blocks proposed
 </Callout>
 
 
-**Epoch Switchovers will happen at approximately 12:00 pm PT on Tuesday (7:00 pm UTC)** every week.
-Please note that all staking operations that interact with staked tokens will be processed by the protocol at the start of each epoch. 
+**Epoch Switchovers will happen at approximately 12:00 pm PT on Wednesday (7:00 pm UTC)** every week. 
+Please note exact epoch ending time vary based on the performance of the network & all staking operations that interact with staked tokens will be processed by the protocol at the start of each epoch. 
 
 ## Rewards
 


### PR DESCRIPTION
Closes: #757 

## Description

<!-- It only corrects the approximate timing of the epoch switchovers.
-->

______

For contributor use:

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
