### PR TITLE
Add SLIP-10 mention to FLIP-200

### DIFF
--- a/flips/20201125-bip-44-multi-account.md
+++ b/flips/20201125-bip-44-multi-account.md
@@ -123,10 +123,7 @@ m / 44' / 1' / 769 / 0 / 0
 ```
 
 All keys generated with the legacy path as of today (Dec 2021) have been done so using the
-ECDSA P256<sup>1</sup> curve.
-
-<sup>1</sup>ECDSA P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on
-the NIST P-256 curve.
+NIST P-256 elliptic curve.
 
 ### Account Discovery
 
@@ -141,7 +138,7 @@ The account index gap limit should be `5`.
 
 The prescribed account discovery procedure is as follows:
 
-1. Derive the key pair using the legacy path and ECDSA P256<sup>1</sup>, 
+1. Derive the key pair using the legacy path and P-256 curve, 
    checking its use with the public key registry. If an address is found, 
    query the Flow network to fetch the account's details. If an account 
    is found, remember the relationship between the path used to generate 
@@ -149,11 +146,11 @@ The prescribed account discovery procedure is as follows:
 2. Derive the key pair(s) (starting with account index = 0 and key index = 0) 
    using the path specified in this FLIP and each elliptic curve that
    both you and Flow support (Flow currently supports keys generated on the
-   ECDSA P256<sup>1</sup> and ECDSA secp256k1<sup>2</sup> curves).
+   P-256 and secp256k1 curves).
    Note: If you are unable to derive keys for a certain elliptic curve, 
    you may fail to discover an account / key that the user has generated 
    previously.
-1. Scan for each keys usage by querying the public key registry with the key and
+3. Scan for each keys usage by querying the public key registry with the key and
    elliptic curve used to generate it.
    If the gap limit has been reached for both key index and account index, stop
    discovery.
@@ -165,20 +162,14 @@ The prescribed account discovery procedure is as follows:
         increment the key index by one.
     - 3.2. If one or more addresses are found, query the Flow network to fetch each
       account's details.
-        - 3.2.1. If no accounts are found<sup>3</sup>, go to step 2, incrementing
+        - 3.2.1. If no accounts are found<sup>1</sup>, go to step 2, incrementing
         the account index by one.
-        - 3.2.2. For each account found<sup>3</sup>, remember the relationship between the path
+        - 3.2.2. For each account found<sup>1</sup>, remember the relationship between the path
         used to generate this key, the curve used to generate this key,
         and the hash algorithm corresponding to this key and the account's details.
         Then go to step 2, incrementing the key index by one.
 
-<sup>1</sup>ECDSA P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on
-the NIST P-256 curve.
-
-<sup>2</sup>ECDSA secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on
-the secp256k1 curve.
-
-<sup>3</sup>Flow supports account deletion, meaning that an address found in the
+<sup>1</sup>Flow supports account deletion, meaning that an address found in the
 registry may refer to a nonexistent account. In this case the address should be
 skipped but discovery should continue.
 

--- a/flips/20201125-bip-44-multi-account.md
+++ b/flips/20201125-bip-44-multi-account.md
@@ -40,6 +40,12 @@ BIP 44 defines an implementation of [Bitcoin Improvement Proposal
 that standardizes a format for hierarchical deterministic (HD) key derivation
 paths that support multiple coins and multiple accounts per coin.
 
+Flow accounts support keys on two different elliptic curves (secp256k1 and NIST P-256).
+While BIP 32 describes the key derivation process for the secp256k1 curve, [SLIP-0010]
+(https://github.com/satoshilabs/slips/blob/master/slip-0010.md) generalizes the derivation 
+process to the NIST P-256 curve. In the rest of this document, BIP 44 is applicable for 
+both elliptic curves. 
+
 The BIP 44 path format is as follows:
 
 ```
@@ -303,6 +309,10 @@ This document outlines a specific application of the standard described by [BIP
 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki). This
 standard has been widely adopted by Bitcoin, Ethereum and many other
 cryptocurrency projects and communities.
+
+[SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) 
+is a document that generalizes the BIP 32 key derivation process
+to other curves, in particular the NIST P-256 curve supported by Flow accounts.
 
 [SLIP 48](https://github.com/satoshilabs/slips/blob/master/slip-0048.md)
 describes an alternative to BIP 44 for Graphene-based networks which, similar to


### PR DESCRIPTION
This PR clarifies how the key derivation from BIP 32 can be used for the P-256 curve. The derivation is done following SLIP-10. This  is applicable for both the legacy path used on Ledger, and for the future implementations of FLIP-200 by other wallets.
