### PR TITLE
Demote Observer Node release notes to alpha

### DIFF
--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -5,7 +5,7 @@ description: Running your own full observer node
 ---
 
 <Callout type="warning">
-  This is an alpha release and is known to contain bugs and is missing functionality. We are currently changing this codebase to address these issues. In the meantime please avoid building a dependency on this code until we're matured this to it's open beta phase
+  This is an alpha release and is known to contain bugs and is missing functionality. We are currently changing this codebase to address these issues. In the meantime please avoid building a dependency on this code until it's re-released to open beta.
 </Callout>
 
 A full observer node is an unstaked access node that follows the flow consensus

--- a/docs/content/node-operation/full-observer-node.mdx
+++ b/docs/content/node-operation/full-observer-node.mdx
@@ -5,7 +5,7 @@ description: Running your own full observer node
 ---
 
 <Callout type="warning">
-  This is an open beta and may contain bugs or be missing functionality.
+  This is an alpha release and is known to contain bugs and is missing functionality. We are currently changing this codebase to address these issues. In the meantime please avoid building a dependency on this code until we're matured this to it's open beta phase
 </Callout>
 
 A full observer node is an unstaked access node that follows the flow consensus


### PR DESCRIPTION
Closes: #???

## Description

We agreed to demote these docs to alpha and warn users off implementing against these until we've made the required changes. 


