### PR TITLE
removing canarynet and mainnet url from the Open API spec

### DIFF
--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -3,12 +3,8 @@ info:
   version: "1.0.0"
   title: "Access API"
 servers:
-  - url: https://rest-mainnet.onflow.org/v1
-    description: Flow Mainnet
   - url: https://rest-testnet.onflow.org/v1
     description: Flow Testnet
-  - url: https://rest-canary.onflow.org/v1
-    description: Flow Canarynet
 paths:
   /blocks:
     get:

--- a/openapi/go-client-generated/README.md
+++ b/openapi/go-client-generated/README.md
@@ -17,7 +17,7 @@ import "./swagger"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/openapi/go-client-generated/api/swagger.yaml
+++ b/openapi/go-client-generated/api/swagger.yaml
@@ -6,12 +6,8 @@ externalDocs:
   description: Find out more about the Access API
   url: https://docs.onflow.org/access-api/
 servers:
-- url: https://rest-mainnet.onflow.org/v1
-  description: Flow Mainnet
 - url: https://rest-testnet.onflow.org/v1
   description: Flow Testnet
-- url: https://rest-canary.onflow.org/v1
-  description: Flow Canarynet
 paths:
   /blocks:
     get:

--- a/openapi/go-client-generated/configuration.go
+++ b/openapi/go-client-generated/configuration.go
@@ -59,7 +59,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "https://rest-mainnet.onflow.org/v1",
+		BasePath:      "https://rest-testnet.onflow.org/v1",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 	}

--- a/openapi/go-client-generated/docs/AccountsApi.md
+++ b/openapi/go-client-generated/docs/AccountsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/BlocksApi.md
+++ b/openapi/go-client-generated/docs/BlocksApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/CollectionsApi.md
+++ b/openapi/go-client-generated/docs/CollectionsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/EventsApi.md
+++ b/openapi/go-client-generated/docs/EventsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/ExecutionResultsApi.md
+++ b/openapi/go-client-generated/docs/ExecutionResultsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/ScriptsApi.md
+++ b/openapi/go-client-generated/docs/ScriptsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/openapi/go-client-generated/docs/TransactionsApi.md
+++ b/openapi/go-client-generated/docs/TransactionsApi.md
@@ -1,6 +1,6 @@
 # {{classname}}
 
-All URIs are relative to *https://rest-mainnet.onflow.org/v1*
+All URIs are relative to *https://rest-testnet.onflow.org/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------


### PR DESCRIPTION
Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
