### PR TITLE
Add NFT metadata contract to documentation site

### DIFF
--- a/docs/content/core-contracts/nft-metadata.mdx
+++ b/docs/content/core-contracts/nft-metadata.mdx
@@ -1,0 +1,16 @@
+---
+title: NFT Metadata Contract
+sidebar_title: NFT Metadata
+---
+
+The `MetadataViews` contract implements a standard to attach on-chain metadata
+to NFTs. This standard was originally proposed in [FLIP-0636](https://github.com/onflow/flow/blob/master/flips/20210916-nft-metadata.md).
+
+It is deployed at the same address as the `NonFungibleToken` contract interface.
+
+Source: [MetadataViews.cdc](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc)
+
+| Network | Contract Address     |
+| ------- | -------------------- |
+| Testnet | `0x631e88ae7f1d7c20` |
+| Mainnet | `0x1d7e57aa55817448` |

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -527,7 +527,8 @@ const sections = [
       "Other Important Contracts": [
         "core-contracts/locked-tokens",
         "core-contracts/staking-collection",
-        "core-contracts/non-fungible-token"
+        "core-contracts/non-fungible-token",
+        "core-contracts/nft-metadata"
       ]
     }
   },


### PR DESCRIPTION
## Description

Add a page for the newly-deployed NFT metadata contract.
