### PR TITLE
[WIP] Add FLIP fest winners to docs site

### DIFF
--- a/docs/content/flip-fest-winners.mdx
+++ b/docs/content/flip-fest-winners.mdx
@@ -6,8 +6,7 @@ FLIP (Flow Improvement Proposals) are a way for Flow developers and users to pro
 to the Flow team about the improvements thye would like to see in Flow.
 
 FLIP Fest was conducted over 3 months with over 100 developers participating in working on issues determined by
-the Flow team and the community for reward bounties
-provided by Flow!
+the Flow team and the community for reward bounties provided by Flow!
 
 The following is a list of the winning projects, their respective developers, and links to their FLIP 
 contribution Github repositories.
@@ -20,19 +19,10 @@ Here are the list of winning submissions in the New Tools category. Congratualti
 ### [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
 
 > **Winner: Congratulations to the flippers!** 🏆
-<a href="https://github.com/bartolomej">@bartolomej </a>
-<br />
-<a href="https://github.com/jgololicic">@jgololicic </a>
-<br />
-<a href="https://github.com/monikaxh">@monikaxh </a>
-<br />
-<a href="https://github.com/blockpilabs">@blockpilabs </a>
-<br />
-
-
-
-
-
+<a href="https://github.com/bartolomej">@bartolomej </a><br />
+<a href="https://github.com/jgololicic">@jgololicic </a><br />
+<a href="https://github.com/monikaxh">@monikaxh </a><br />
+<a href="https://github.com/blockpilabs">@blockpilabs </a><br />
 
 #### Challenge Summary 
 
@@ -56,6 +46,9 @@ When an event occurs, the application will update its internal state (e.g. a dat
 ### [Cadence support for IntelliJ Platform](https://github.com/onflow/flip-fest/issues/19)
 
 > **Winner: Congratulations to freeflowers!** 🏆
+<a href="https://github.com/NikitasKotsolakos">@NikitasKotsolakos </a>
+
+
 
 #### Challenge Summary 
 
@@ -66,6 +59,10 @@ Goal is to integrate basic Cadence editing features into the IntelliJ Platform, 
 ### [Flow Rust SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to fee-1-dead!** 🏆
+<a href="https://github.com/MarshallBelles">@MarshallBelles </a><br/>
+<a href="https://github.com/bluesign">@bluesign </a><br/>
+<a href="https://github.com/fee-1-dead">@fee-1-dead </a><br/>
+
 
 #### Challenge Summary 
 
@@ -76,6 +73,8 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 ### [Flow Ruby SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to nduplessis!** 🏆
+<a href="https://github.com/nduplessis">@nduplessis </a>
+
 
 #### Challenge Summary 
 
@@ -86,6 +85,9 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 ### [Flow .NET SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to tyronbrand!** 🏆
+<a href="https://github.com/tyronbrand">@tyronbrand </a>
+
+
 
 #### Challenge Summary 
 
@@ -96,6 +98,7 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 ### [Flow Swift SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to lmcmz!** 🏆
+<a href="https://github.com/lmcmz">@lmcmz </a>
 
 #### Challenge Summary 
 
@@ -108,6 +111,9 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 ### CryptoDappy: [NFT Marketplace](https://github.com/onflow/flip-fest/issues/5)
 
 > **Winner: Congratulations to phillip62_a774 (ph0ph0)!** 🏆
+<a href="https://github.com/NguyenIvan">@NguyenIvan </a>
+
+
 
 #### Challenge Summary 
 
@@ -118,6 +124,8 @@ We want to give users the experience to list their Dappies (NFTs) for sale in or
 ### CryptoDappy: [localization (I18n) solution](https://github.com/onflow/flip-fest/issues/6)
 
 > **Winner: Congratulations to nagato1_c511 (knagato)!** 🏆
+<a href="https://github.com/knagato">@knagato</a>
+
 
 #### Challenge Summary 
 
@@ -126,6 +134,9 @@ Community members have already published some translated documents (e.g. Vietnam
 ---
 
 ### Dev Wallet: [Improve OpenID implementation](https://github.com/onflow/flip-fest/issues/10)
+
+> **Winner: Congratulations to wfalcon0x!** 🏆
+<a href="https://github.com/wfalcon0x">@wfalcon0x </a>
 
 #### Challenge Summary 
 
@@ -136,6 +147,8 @@ Dapps should be able to define and request user information (as per OpenID Stand
 ### Flow Emulator: [Report gas used](https://github.com/onflow/flip-fest/issues/12)
 
 > **Winner: Congratulations to nagato1_c511 (avcdsld)!** 🏆
+<a href="https://github.com/avcdsld">@avcdsld </a>
+
 
 #### Challenge Summary 
 
@@ -146,6 +159,8 @@ There should be a way to see transaction gas (computation) usage.
 ### Flow Emulator: [Bootstrap with default contracts](https://github.com/onflow/flip-fest/issues/27)
 
 > **Winner: Congratulations to the FlashyTigers!** 🏆
+<a href="https://github.com/mwufi">@mwufi </a>
+
 
 #### Challenge Summary
 
@@ -160,6 +175,8 @@ The emulator should be able to deploy contracts when it starts up. For Example:
 ### Flow CLI: [Hot Command](https://github.com/onflow/flip-fest/issues/14)
 
 > **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** 🏆
+<a href="https://github.com/sakshamb2113">@sakshamb2113 </a>
+
 
 #### Challenge Summary 
 
@@ -170,6 +187,9 @@ The flow CLI should be customized to provide easy access to common commands.
 ### Flow CLI: [State management](https://github.com/onflow/flip-fest/issues/22)
 
 > **Winner: Congratulations to the Non Fungibles!** 🏆
+<a href="https://github.com/bluesign">@bluesign</a>
+
+
 
 #### Challenge Summary
 
@@ -180,6 +200,8 @@ Flow developers use the playground to learn, experiment, and share Cadence code.
 ### Flow CLI: [Launch FCL development wallet](https://github.com/onflow/flip-fest/issues/11)
 
 > **Winner: Congratulations to bluesign!** 🏆
+<a href="https://github.com/bluesign">@bluesign </a>
+
 
 #### Challenge Summary
 
@@ -190,6 +212,8 @@ This effort proposes bundling the dev wallet server as part of the emulator, and
 ### Flow Playground: [Markdown READMEs](https://github.com/onflow/flip-fest/issues/18)
 
 > **Winner: Congratulations to Team Exponential!** 🏆
+<a href="https://github.com/hichana"> hichana </a><br/>
+<a href="https://github.com/justjoolz"> justjoolz </a>
 
 #### Challenge Summary 
 
@@ -200,6 +224,9 @@ The goal of this task is to add a feature to the playground that allows develope
 ### Flow Playground: [Multiple contracts per account](https://github.com/onflow/flip-fest/issues/21)
 
 > **Winner: Congratulations to squidplay!** 🏆
+<a href="https://github.com/jakic12">@jakic12 </a><br />
+<a href="https://github.com/bartolomej">@bartolomej </a>
+
 
 #### Challenge Summary 
 
@@ -210,6 +237,9 @@ Flow developers use the playground to learn, experiment, and share Cadence code.
 ### Flow Playground: [Improve the resource explorer](https://github.com/onflow/flip-fest/issues/29)
 
 > **Winner: Congratulations to the Team Exponential!** 🏆
+<a href="https://github.com/hichana">@hichana </a><br />
+<a href="https://github.com/justjoolz">@justjoolz </a>
+
 
 #### Challenge Summary
 
@@ -220,6 +250,8 @@ In the playground, the resource explorer is the tab the shows the resources insi
 ### Flow Playground: [Fix client-side errors in the playground frontend](https://github.com/onflow/flip-fest/issues/58)
 
 > **Winner: Congratulations to the hichana!** 🏆
+<a href="https://github.com/hichana">@hichana </a>
+
 
 #### Challenge Summary
 
@@ -230,6 +262,8 @@ The Flow Playground frontend app throws a number of console errors in product. T
 ### Non-React FCL Usage: [Dapp example](https://github.com/onflow/flip-fest/issues/23)
 
 > **Winner: Congratulations to the Enouvo!** 🏆
+<a href="https://github.com/amitkothari">@amitkothari </a>
+<a href="https://github.com/ic3guy">@ic3guy </a>
 
 #### Challenge Summary 
 
@@ -240,6 +274,7 @@ While using FCL is possible in non-react example, we do not have many examples i
 ### FCL: [Calculate the transaction hash](https://github.com/onflow/flip-fest/issues/24)
 
 > **Winner: Congratulations to the nagato1_c511!** 🏆
+<a href="https://github.com/avcdsld">@avcdsld </a>
 
 #### Challenge Summary 
 
@@ -250,6 +285,9 @@ Get the transaction hash before it's sent to the blockchain for FCL.
 ### Flow Providers: [Non-custodial Wallets](https://github.com/onflow/flip-fest/issues/28)
 
 > **Winner: Congratulations to the Zaycodes!** 🏆
+<a href="https://github.com/aishairzay"> aishairzay </a><br/>
+<a href="https://github.com/zerooverride"> zerooverride </a><br/>
+<a href="https://github.com/OmarMalik"> OmarMalik </a><br/>
 
 #### Challenge Summary 
 
@@ -260,6 +298,9 @@ Create a non-custodial FCL compatiable wallet.
 ### JS Testing: [Multiple return values from interaction](https://github.com/onflow/flip-fest/issues/30)
 
 > **Winner: Congratulations to the Team Exponential!** 🏆
+<a href="https://github.com/hichana">@hichana </a><br />
+<a href="https://github.com/justjoolz">@justjoolz </a>
+
 
 #### Challenge Summary 
 
@@ -270,6 +311,8 @@ The JS Testing Framework has two functions: sendTransaction and executeScript th
 ### Improve Existing SDK: [Python](https://github.com/onflow/flip-fest/issues/46)
 
 > **Winner: Congratulations to the barekati!** 🏆
+<a href="https://github.com/barekati">@barekati </a>
+
 
 #### Challenge Summary 
 
@@ -278,6 +321,10 @@ Improve the Python SDK to meet the `onflow/sdks` guidelines.
 ---
 
 ### VS Code Extension: [Architecture improvements](https://github.com/onflow/flip-fest/issues/3)
+
+> **Winner: Congratulations to koala!** 🏆
+<a href="https://github.com/eburnette">@eburnette </a>
+
 
 #### Challenge Summary 
 
@@ -309,6 +356,7 @@ The current Flow NFT interface, however, does not include a metadata standard th
 ### [Decentralized identifiers (DIDs) on Flow](https://github.com/onflow/flip-fest/issues/17)
 
 > **Winner: Congratulations to the mwufi!** 🏆
+<a href="https://github.com/mwufi">@mwufi </a>
 
 #### Challenge Summary 
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -48,6 +48,73 @@ import { IconGithub, IconDiscord, IconDiscourse } from "gatsby-theme-flow/src/ui
 </div>
 
 <div className="grid-item">
+  <h3>🤝 Community Code</h3>
+  <ul className="grid-item-list">
+  <li>
+    <TrackingLink
+      href="/flip-fest-winners/"
+      eventName="Homepage_link_/fcl/tutorials/flow-app-quickstart/_clicked"
+    >
+      FLIP Fest Winners!
+    </TrackingLink>
+    <br />
+    <p>
+     FLIP Fest was conducted over 3 months with over 100 developers participating in working on issues determined by
+      the Flow team and the community for reward bounties provided by Flow!
+    </p>
+    <p>
+      <TrackingLink
+        href="winners/#new-tools"
+        eventName="Homepage_link_FLIP-new-tools_clicked"
+      >
+       New Tools
+      </TrackingLink>
+      <br />
+      <TrackingLink
+        href="winners/#new-features--improvements"
+        eventName="Homepage_link_FLIP-new-features_clicked">
+        New Features & Improvements
+      </TrackingLink>
+      <br />
+      <TrackingLink
+        href="winners/#new-features--improvements"
+        eventName="Homepage_link_FLIP-new-features_clicked"
+      >
+        New Standards
+      </TrackingLink>
+    </p>
+  </li>
+  <li>
+    <TrackingLink
+      href="https://github.com/muttoni/gold-star-contracts
+"
+      eventName="Homepage_link_/gold-star-contracts/_clicked"
+    >
+     ⭐️ Gold Star Contracts
+    </TrackingLink>{" "}
+    <br />
+    <p>
+     A non-exhaustive list of Cadence contracts, scripts, transactions that exemplify best practices.
+     These contracts are so-called foundational because they are standard interfaces that any FT or NFT contract will implement. They introduce commonly seen resources such as Vaults, Collections as well as standard events.
+    </p>
+  </li>
+  <li>
+    <TrackingLink
+      href="https://github.com/ph0ph0/Get-The-Flow-Down"
+      eventName="Homepage_link_/get-the-flow-down/_clicked"
+    >
+      The 'Flow Down'
+    </TrackingLink>{" "}
+    <br />
+    <p>
+     Get the Flow Down is a curated collection of the best Flow blockchain tools, tutorials, articles and more! If you have come across an awesome tutorial, tool, community, blog or you have created one yourself, please create a PR!
+    </p>
+  </li>
+</ul>
+
+</div>
+
+<div className="grid-item">
 <h3>🏄🏼‍♂️ Learn Cadence</h3>
 
   <ul className="grid-item-list">

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -1,221 +1,327 @@
-# FLIP Fest Winners
-
+---
+title: FLIP fest Winners!
 ---
 
-## New Tool: [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
+## New Tools
 
-> **Winner: Congratulations to the Flippers!** 
+### [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
 
-### Issue Summary
+> **Winner: Congratulations to the flippers!** 🏆
+
+#### Challenge Summary 
 
 Build a graphical user interface (GUI) that simplifies the network state into visual elements, allows for simple interactions, and is optimized for debugging and inspecting the Flow blockchain state.
 
+<table style="width: 100%;">
+  <tbody>
+    <tr>
+      <th>Team Name</th>
+      <th align="center">Github Username(s)</th>
+      <th align="center">Milestones Completed</th>
+      <th align="center">Demo/Repo/Final PR</th>
+    </tr>
+    <tr>
+      <td><i>flippers</i></td>
+      <td align="left">
+        <ul>
+            <li> <a href="https://github.com/bartolomej"> bartolomej </a></li>
+            <li><a href="https://github.com/monikaxh"> monikaxh </a></li>
+            <li><a href="https://github.com/jgololicic"> jgololicic </a></li>
+        </ul>
+      </td>
+      <td align="right">4/4</td>
+      <td align="left">
+        <ul>
+            <li> <a href="https://flowser.dev"> Flowser Project Website </a></li>
+            <li><a href="https://github.com/onflowser/flowser"> Flowser Repo </a></li>
+            <li><a href="https://www.youtube.com/watch?v=yMs5awvGnlY"> Video Demo </a></li>
+        </ul>
+     </td>
+     </tr>
+  </tbody>
+</table>
 
---- 
+<table>
+    <tbody>
+        <tr>
+            <th align="center">Milestone Submission Rewards</th>
+            <th align="center">Winning Submission Rewards</th>
+            <th align="center">Bonus Submission Rewards</th>
+            <th align="center">Total Team Payout</th>
+        </tr>
+        <tr>
+            <td >$8,750</td>
+            <td >$50,000</td>
+            <td >N/A</td>
+            <td >$58,750</td>
+        </tr>
+    </tbody>
+</table>
 
-## VS Code Extension: [Architecture improvements](https://github.com/onflow/flip-fest/issues/3)
+#### Payout summary
 
-### Issue Summary
+<table>
+  <tbody>
+    <tr>
+      <th>Team Name</th>
+      <th align="center">Github Username</th>
+      <th align="center">% Allocation</th>
+      <th align="center">Total Reward Amount </th>
+      <th align="center">FLOW Amount</th>
+    </tr>
+    <tr>
+      <td>
+        <i>flippers</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/bartolomej"> bartolomej </a>
+      </td>
+      <td align="right">36.5%</td>
+      <td align="right">$21,444</td>
+      <td align="right">TBD</td>
+    </tr>
+    <tr>
+      <td>
+        <i>flippers</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/jgololicic"> jgololicic </a>
+      </td>
+      <td align="right">45.5%</td>
+      <td align="right">$26,731</td>
+      <td align="right">TBD</td>
+    </tr>
+    <tr>
+      <td>
+        <i>flippers</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/monikaxh"> monikaxh </a>
+      </td>
+      <td align="right">18%</td>
+      <td align="right">$10,575</td>
+      <td align="right">TBD</td>
+    </tr>
+    <tr>
+      <td>
+        <i>blockpi</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/blockpilabs"> blockpilabs </a>
+      </td>
+      <td align="right">100%</td>
+      <td align="right">$250</td>
+      <td align="right">TBD</td>
+    </tr>
+  </tbody>
+</table>
 
-The VS Code extension architecture could be improved so the extension becomes lighter and only handles the communication with the language server and the UI.
+
 
 ---
 
-## CryptoDappy Feature: [NFT Marketplace](https://github.com/onflow/flip-fest/issues/5)
-
-> **Winner: Congratulations to phillip62_a774 (ph0ph0)!** 🏆
-
-### Issue Summary
-
-We want to give users the experience to list their Dappies (NFTs) for sale in order to sell them to other buyers, and give buyers a chance to purchase Dappies of other users.
-
----
-
-## CryptoDappy Feature: [localization (I18n) solution](https://github.com/onflow/flip-fest/issues/6)
-
-> **Winner: Congratulations to nagato1_c511 (knagato)!** 🏆
-
-### Issue Summary
-
-Community members have already published some translated documents (e.g. Vietnamese version), but the basic functionality of changing the language on the Learning Hub has not been implemented yet.
-
----
-
-## Dev Wallet Feature: [Improve OpenID implementation](https://github.com/onflow/flip-fest/issues/10)
-
-### Issue Summary
-
-Dapps should be able to define and request user information (as per OpenID Standards) from FCL compatible wallet providers so that they can associate the account address with identity fields.
-
----
-
-
-## CLI Feature: [Launch FCL development wallet](https://github.com/onflow/flip-fest/issues/11)
-
-> **Winner: Congratulations to bluesign!** 🏆
-
-### Issue Summary
-
-This effort proposes bundling the dev wallet server as part of the emulator, and starting the wallet service alongside the emulator when working locally, removing the necessity for users to configure and run the dev wallet docker container manually.
-
----
-
-## Emulator Feature: [Report gas used](https://github.com/onflow/flip-fest/issues/12)
-
-> **Winner: Congratulations to nagato1_c511 (avcdsld)!** 🏆
-
-### Issue Summary
-
-There should be a way to see transaction gas (computation) usage.
-
----
-
-## CLI Feature: [Hot Command](https://github.com/onflow/flip-fest/issues/14)
-
-> **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** 🏆
-
-### Issue Summary
-
-The flow CLI should be customized to provide easy access to common commands.
-
----
-
-## New Tool: [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
+### [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
 
 > **Winner: Congratulations to chris615_dad2 (chriswayoub)!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 When an event occurs, the application will update its internal state (e.g. a database) or notify its users of the on-chain activity. Many teams have integrated event tracking systems directly into their application infrastructure, but this is a common enough problem that it warrants a simple and general-purpose solution that can serve all teams.
 
+<table style="width: 100%;">
+  <tbody>
+    <tr>
+      <th>Team Name</th>
+      <th align="center">Github Username(s)</th>
+      <th align="center">Milestones Completed</th>
+      <th align="center">Demo/Repo/Final PR</th>
+    </tr>
+    <tr>
+        <td>
+        <i>chris615_dad2 </i>
+        </td>
+        <td align="left">
+            <ul>
+                <li>
+                <a href="https://github.com/chriswayoub"> chriswayoub </a>
+                </li>
+            </ul>
+        </td>
+        <td align="right">4/4</td>
+        <td align="left">
+        <ul>
+            <li>
+            <a href="https://github.com/onflow/flip-fest/tree/main/submissions/issue-15/milestone-4/pratik1719_a2eb9">
+                Last PR
+            </a>
+            </li>
+            <li>
+            <a href="https://github.com/rayvin-flow/flow-scanner">
+                Flow Scanner Service
+            </a>
+            </li>
+            <li>
+            <a href="https://github.com/rayvin-flow/flow-scanner-lib">
+                Flow Scanner Library
+            </a>
+            </li>
+        </ul>
+        </td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <tbody>
+    <tr>
+      <th align="center">Milestone Submission Rewards</th>
+      <th align="center">Winning Submission Rewards</th>
+      <th align="center">Bonus Submission Rewards</th>
+      <th align="center">Total Team Payout</th>
+    </tr>
+    <tr>
+        <td align="right">$8,750</td>
+        <td align="right">$0</td>
+        <td align="right">$25,000</td>
+        <td align="right">$33,750</td>
+    </tr>
+    
+  </tbody>
+</table>
+
+<table>
+  <tbody>
+    <tr>
+      <th>Team Name</th>
+      <th align="center">Github Username</th>
+      <th align="center">% Allocation</th>
+      <th align="center">Total Reward Amount (USD) </th>
+      <th align="center">Flow Amount</th>
+    </tr>
+    <tr>
+      <td>
+        <i>chris615_dad2</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/chriswayoub"> chriswayoub </a>
+      </td>
+      <td align="right">100%</td>
+      <td align="right">$58,750</td>
+      <td align="right">TBD</td>
+    </tr>
+    <tr>
+      <td>
+        <i>pratik1719_a2eb</i>
+      </td>
+      <td align="left">
+        <a href="https://github.com/prpatel05"> prpatel05 </a>
+      </td>
+      <td align="right">100%</td>
+      <td align="right">$33,750</td>
+      <td align="right">TBD</td>
+    </tr>
+  </tbody>
+</table>
+
+
 
 ---
 
-## New Standard: [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
-
-> **Winner: Congratulations to the Non Fungibles!** 🏆
-
-### Issue Summary
-
-The current Flow NFT interface, however, does not include a metadata standard that allows these representations to flourish. NFTs should be able to include structured data, images, videos and other types of data.
-
----
-
-## New Standard: [Decentralized identifiers (DIDs) on Flow](https://github.com/onflow/flip-fest/issues/17)
-
-> **Winner: Congratulations to the mwufi!** 🏆
-
-### Issue Summary
-
-Flow could benefit from dedicated DID infrastructure for interoperating Flow identities with services outside of Flow, such as decentralized data storage and credential verification systems.
-
----
-
-## Playground Feature: [Markdown READMEs](https://github.com/onflow/flip-fest/issues/18)
-
-> **Winner: Congratulations to Team Exponential!** 🏆
-
-### Issue Summary
-
-The goal of this task is to add a feature to the playground that allows developers to add a written description to their projects, similar to README files in git repositories.
-
----
-
-## New Tool: [Add Cadence support for IntelliJ Platform](https://github.com/onflow/flip-fest/issues/19)
+### [Cadence support for IntelliJ Platform](https://github.com/onflow/flip-fest/issues/19)
 
 > **Winner: Congratulations to freeflowers!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 Goal is to integrate basic Cadence editing features into the IntelliJ Platform, an IDE framework developed by JetBrains. Although IntelliJ itself is a Java editor, it is possible to write a plugin that adds Cadence language support to all IntelliJ-based editors (e.g. PyCharm, WebStorm).
 
 ---
 
-## New Tool: [Build a Flow .NET SDK](https://github.com/onflow/flip-fest/issues/20)
-
-> **Winner: Congratulations to tyronbrand!** 🏆
-
-### Issue Summary
-
-We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
-
----
-
-## New Tool: [Build a Flow Swift SDK](https://github.com/onflow/flip-fest/issues/20)
-
-> **Winner: Congratulations to lmcmz!** 🏆
-
-### Issue Summary
-
-We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
-
----
-
-## New Tool: [Build a Flow Rust SDK](https://github.com/onflow/flip-fest/issues/20)
+### [Flow Rust SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to fee-1-dead!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
 
 ---
 
-## New Tool: [Build a Flow Ruby SDK](https://github.com/onflow/flip-fest/issues/20)
+### [Flow Ruby SDK](https://github.com/onflow/flip-fest/issues/20)
 
 > **Winner: Congratulations to nduplessis!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
 
 ---
 
-## Playground Feature: [Multiple contracts per account](https://github.com/onflow/flip-fest/issues/21)
+### [Flow .NET SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to squidplay!** 🏆
+> **Winner: Congratulations to tyronbrand!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
-Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
-
----
-
-## CLI Feature: [State management](https://github.com/onflow/flip-fest/issues/22)
-
-> **Winner: Congratulations to the Non Fungibles!** 🏆
-
-### Issue Summary
-
-Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
 
 ---
 
-## Non-React FCL Usage: [Dapp example](https://github.com/onflow/flip-fest/issues/23)
+### [Flow Swift SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to the Enouvo!** 🏆
+> **Winner: Congratulations to lmcmz!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
-While using FCL is possible in non-react example, we do not have many examples in the community of this usage. There are some issues with installing the FCL package directly due to packages used to support GRPC.
-
----
-
-## FCL Feature: [Calculate the transaction hash](https://github.com/onflow/flip-fest/issues/24)
-
-> **Winner: Congratulations to the nagato1_c511!** 🏆
-
-### Issue Summary
-
-Get the transaction hash before it's sent to the blockchain for FCL.
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
 
 ---
 
-## Emulator Feature: [Bootstrap with default contracts](https://github.com/onflow/flip-fest/issues/27)
+## New Features & Improvements
+
+### CryptoDappy: [NFT Marketplace](https://github.com/onflow/flip-fest/issues/5)
+
+> **Winner: Congratulations to phillip62_a774 (ph0ph0)!** 🏆
+
+#### Challenge Summary 
+
+We want to give users the experience to list their Dappies (NFTs) for sale in order to sell them to other buyers, and give buyers a chance to purchase Dappies of other users.
+
+---
+
+### CryptoDappy: [localization (I18n) solution](https://github.com/onflow/flip-fest/issues/6)
+
+> **Winner: Congratulations to nagato1_c511 (knagato)!** 🏆
+
+#### Challenge Summary 
+
+Community members have already published some translated documents (e.g. Vietnamese version), but the basic functionality of changing the language on the Learning Hub has not been implemented yet.
+
+---
+
+### Dev Wallet: [Improve OpenID implementation](https://github.com/onflow/flip-fest/issues/10)
+
+#### Challenge Summary 
+
+Dapps should be able to define and request user information (as per OpenID Standards) from FCL compatible wallet providers so that they can associate the account address with identity fields.
+
+---
+
+### Flow Emulator: [Report gas used](https://github.com/onflow/flip-fest/issues/12)
+
+> **Winner: Congratulations to nagato1_c511 (avcdsld)!** 🏆
+
+#### Challenge Summary 
+
+There should be a way to see transaction gas (computation) usage.
+
+---
+
+### Flow Emulator: [Bootstrap with default contracts](https://github.com/onflow/flip-fest/issues/27)
 
 > **Winner: Congratulations to the FlashyTigers!** 🏆
 
-### Issue Summary
+#### Challenge Summary
 
 The emulator should be able to deploy contracts when it starts up. For Example:
 
@@ -225,50 +331,153 @@ The emulator should be able to deploy contracts when it starts up. For Example:
 
 ---
 
-## Flow Providers: [Non-custodial Wallets](https://github.com/onflow/flip-fest/issues/28)
+### Flow CLI: [Hot Command](https://github.com/onflow/flip-fest/issues/14)
 
-> **Winner: Congratulations to the Zaycodes!** 🏆
+> **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
-Create a non-custodial FCL compatiable wallet.
+The flow CLI should be customized to provide easy access to common commands.
 
 ---
 
-## Playground Feature: Improve the resource explorer [#29](https://github.com/onflow/flip-fest/issues/29)
+### Flow CLI: [State management](https://github.com/onflow/flip-fest/issues/22)
+
+> **Winner: Congratulations to the Non Fungibles!** 🏆
+
+#### Challenge Summary
+
+Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
+
+---
+
+### Flow CLI: [Launch FCL development wallet](https://github.com/onflow/flip-fest/issues/11)
+
+> **Winner: Congratulations to bluesign!** 🏆
+
+#### Challenge Summary
+
+This effort proposes bundling the dev wallet server as part of the emulator, and starting the wallet service alongside the emulator when working locally, removing the necessity for users to configure and run the dev wallet docker container manually.
+
+---
+
+### Flow Playground: [Markdown READMEs](https://github.com/onflow/flip-fest/issues/18)
+
+> **Winner: Congratulations to Team Exponential!** 🏆
+
+#### Challenge Summary 
+
+The goal of this task is to add a feature to the playground that allows developers to add a written description to their projects, similar to README files in git repositories.
+
+---
+
+### Flow Playground: [Multiple contracts per account](https://github.com/onflow/flip-fest/issues/21)
+
+> **Winner: Congratulations to squidplay!** 🏆
+
+#### Challenge Summary 
+
+Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
+
+---
+
+### Flow Playground: [Improve the resource explorer](https://github.com/onflow/flip-fest/issues/29)
 
 > **Winner: Congratulations to the Team Exponential!** 🏆
 
-### Issue Summary
+#### Challenge Summary
 
 In the playground, the resource explorer is the tab the shows the resources inside each account. It is hidden initially and only shows up once you interact with an account's storage. But even then, it only shows up after you click an account, which usually decouples the view a transaction that updates the stored resources.
 
 ---
 
-## JS Testing Feature: [Multiple return values from interaction](https://github.com/onflow/flip-fest/issues/30)
+### Flow Playground: [Fix client-side errors in the playground frontend](https://github.com/onflow/flip-fest/issues/58)
+
+> **Winner: Congratulations to the hichana!** 🏆
+
+#### Challenge Summary
+
+The Flow Playground frontend app throws a number of console errors in product. Those errors shouldn't be there.
+
+---
+
+### Non-React FCL Usage: [Dapp example](https://github.com/onflow/flip-fest/issues/23)
+
+> **Winner: Congratulations to the Enouvo!** 🏆
+
+#### Challenge Summary 
+
+While using FCL is possible in non-react example, we do not have many examples in the community of this usage. There are some issues with installing the FCL package directly due to packages used to support GRPC.
+
+---
+
+### FCL: [Calculate the transaction hash](https://github.com/onflow/flip-fest/issues/24)
+
+> **Winner: Congratulations to the nagato1_c511!** 🏆
+
+#### Challenge Summary 
+
+Get the transaction hash before it's sent to the blockchain for FCL.
+
+---
+
+### Flow Providers: [Non-custodial Wallets](https://github.com/onflow/flip-fest/issues/28)
+
+> **Winner: Congratulations to the Zaycodes!** 🏆
+
+#### Challenge Summary 
+
+Create a non-custodial FCL compatiable wallet.
+
+---
+
+### JS Testing: [Multiple return values from interaction](https://github.com/onflow/flip-fest/issues/30)
 
 > **Winner: Congratulations to the Team Exponential!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 The JS Testing Framework has two functions: sendTransaction and executeScript that currently return a single result from their execution. It does not have a good way of handling errors that should be caught and processed. This can cause issues with multiple interactions called in succession.
 
 ---
 
-## Improve Existing SDK: [Python](https://github.com/onflow/flip-fest/issues/46)
+### Improve Existing SDK: [Python](https://github.com/onflow/flip-fest/issues/46)
 
 > **Winner: Congratulations to the barekati!** 🏆
 
-### Issue Summary
+#### Challenge Summary 
 
 Improve the Python SDK to meet the `onflow/sdks` guidelines.
 
 ---
 
-## Playground: [Fix client-side errors in the playground frontend](https://github.com/onflow/flip-fest/issues/58)
+### VS Code Extension: [Architecture improvements](https://github.com/onflow/flip-fest/issues/3)
 
-> **Winner: Congratulations to the hichana!** 🏆
+#### Challenge Summary 
 
-### Issue Summary
+The VS Code extension architecture could be improved so the extension becomes lighter and only handles the communication with the language server and the UI.
 
-The Flow Playground frontend app throws a number of console errors in product. Those errors shouldn't be there.
+---
+
+## New Standards
+
+### [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
+
+> **Winner: Congratulations to the Non Fungibles!** 🏆
+
+#### Challenge Summary 
+
+The current Flow NFT interface, however, does not include a metadata standard that allows these representations to flourish. NFTs should be able to include structured data, images, videos and other types of data.
+
+---
+
+### [Decentralized identifiers (DIDs) on Flow](https://github.com/onflow/flip-fest/issues/17)
+
+> **Winner: Congratulations to the mwufi!** 🏆
+
+#### Challenge Summary 
+
+Flow could benefit from dedicated DID infrastructure for interoperating Flow identities with services outside of Flow, such as decentralized data storage and credential verification systems.
+
+
+

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -23,7 +23,7 @@ The VS Code extension architecture could be improved so the extension becomes li
 
 ## CryptoDappy Feature: [NFT Marketplace](https://github.com/onflow/flip-fest/issues/5)
 
-> **Winner: Congratulations to phillip62_a774 (ph0ph0)!** :tada:
+> **Winner: Congratulations to phillip62_a774 (ph0ph0)!** 🏆
 
 ### Issue Summary
 
@@ -33,7 +33,7 @@ We want to give users the experience to list their Dappies (NFTs) for sale in or
 
 ## CryptoDappy Feature: [localization (I18n) solution](https://github.com/onflow/flip-fest/issues/6)
 
-> **Winner: Congratulations to nagato1_c511 (knagato)!** :tada:
+> **Winner: Congratulations to nagato1_c511 (knagato)!** 🏆
 
 ### Issue Summary
 
@@ -52,7 +52,7 @@ Dapps should be able to define and request user information (as per OpenID Stand
 
 ## CLI Feature: [Launch FCL development wallet](https://github.com/onflow/flip-fest/issues/11)
 
-> **Winner: Congratulations to bluesign!** :tada:
+> **Winner: Congratulations to bluesign!** 🏆
 
 ### Issue Summary
 
@@ -62,7 +62,7 @@ This effort proposes bundling the dev wallet server as part of the emulator, and
 
 ## Emulator Feature: [Report gas used](https://github.com/onflow/flip-fest/issues/12)
 
-> **Winner: Congratulations to nagato1_c511 (avcdsld)!** :tada:
+> **Winner: Congratulations to nagato1_c511 (avcdsld)!** 🏆
 
 ### Issue Summary
 
@@ -72,7 +72,7 @@ There should be a way to see transaction gas (computation) usage.
 
 ## CLI Feature: [Hot Command](https://github.com/onflow/flip-fest/issues/14)
 
-> **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** :tada:
+> **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** 🏆
 
 ### Issue Summary
 
@@ -82,7 +82,7 @@ The flow CLI should be customized to provide easy access to common commands.
 
 ## New Tool: [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
 
-> **Winner: Congratulations to chris615_dad2 (chriswayoub)!** :tada:
+> **Winner: Congratulations to chris615_dad2 (chriswayoub)!** 🏆
 
 ### Issue Summary
 
@@ -93,7 +93,7 @@ When an event occurs, the application will update its internal state (e.g. a dat
 
 ## New Standard: [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
 
-> **Winner: Congratulations to the Non Fungibles!** :tada:
+> **Winner: Congratulations to the Non Fungibles!** 🏆
 
 ### Issue Summary
 
@@ -103,7 +103,7 @@ The current Flow NFT interface, however, does not include a metadata standard th
 
 ## New Standard: [Decentralized identifiers (DIDs) on Flow](https://github.com/onflow/flip-fest/issues/17)
 
-> **Winner: Congratulations to the mwufi!** :tada:
+> **Winner: Congratulations to the mwufi!** 🏆
 
 ### Issue Summary
 
@@ -113,7 +113,7 @@ Flow could benefit from dedicated DID infrastructure for interoperating Flow ide
 
 ## Playground Feature: [Markdown READMEs](https://github.com/onflow/flip-fest/issues/18)
 
-> **Winner: Congratulations to Team Exponential!** :tada:
+> **Winner: Congratulations to Team Exponential!** 🏆
 
 ### Issue Summary
 
@@ -123,7 +123,7 @@ The goal of this task is to add a feature to the playground that allows develope
 
 ## New Tool: [Add Cadence support for IntelliJ Platform](https://github.com/onflow/flip-fest/issues/19)
 
-> **Winner: Congratulations to freeflowers!** :tada:
+> **Winner: Congratulations to freeflowers!** 🏆
 
 ### Issue Summary
 
@@ -133,7 +133,7 @@ Goal is to integrate basic Cadence editing features into the IntelliJ Platform, 
 
 ## New Tool: [Build a Flow .NET SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to tyronbrand!** :tada:
+> **Winner: Congratulations to tyronbrand!** 🏆
 
 ### Issue Summary
 
@@ -143,7 +143,7 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 
 ## New Tool: [Build a Flow Swift SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to lmcmz!** :tada:
+> **Winner: Congratulations to lmcmz!** 🏆
 
 ### Issue Summary
 
@@ -153,7 +153,7 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 
 ## New Tool: [Build a Flow Rust SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to fee-1-dead!** :tada:
+> **Winner: Congratulations to fee-1-dead!** 🏆
 
 ### Issue Summary
 
@@ -163,7 +163,7 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 
 ## New Tool: [Build a Flow Ruby SDK](https://github.com/onflow/flip-fest/issues/20)
 
-> **Winner: Congratulations to nduplessis!** :tada:
+> **Winner: Congratulations to nduplessis!** 🏆
 
 ### Issue Summary
 
@@ -173,7 +173,7 @@ We are looking for teams interested in building and maintaining SDKs for Flow to
 
 ## Playground Feature: [Multiple contracts per account](https://github.com/onflow/flip-fest/issues/21)
 
-> **Winner: Congratulations to squidplay!** :tada:
+> **Winner: Congratulations to squidplay!** 🏆
 
 ### Issue Summary
 
@@ -183,7 +183,7 @@ Flow developers use the playground to learn, experiment, and share Cadence code.
 
 ## CLI Feature: [State management](https://github.com/onflow/flip-fest/issues/22)
 
-> **Winner: Congratulations to the Non Fungibles!** :tada:
+> **Winner: Congratulations to the Non Fungibles!** 🏆
 
 ### Issue Summary
 
@@ -193,7 +193,7 @@ Flow developers use the playground to learn, experiment, and share Cadence code.
 
 ## Non-React FCL Usage: [Dapp example](https://github.com/onflow/flip-fest/issues/23)
 
-> **Winner: Congratulations to the Enouvo!** :tada:
+> **Winner: Congratulations to the Enouvo!** 🏆
 
 ### Issue Summary
 
@@ -203,7 +203,7 @@ While using FCL is possible in non-react example, we do not have many examples i
 
 ## FCL Feature: [Calculate the transaction hash](https://github.com/onflow/flip-fest/issues/24)
 
-> **Winner: Congratulations to the nagato1_c511!** :tada:
+> **Winner: Congratulations to the nagato1_c511!** 🏆
 
 ### Issue Summary
 
@@ -213,7 +213,7 @@ Get the transaction hash before it's sent to the blockchain for FCL.
 
 ## Emulator Feature: [Bootstrap with default contracts](https://github.com/onflow/flip-fest/issues/27)
 
-> **Winner: Congratulations to the FlashyTigers!** :tada:
+> **Winner: Congratulations to the FlashyTigers!** 🏆
 
 ### Issue Summary
 
@@ -227,7 +227,7 @@ The emulator should be able to deploy contracts when it starts up. For Example:
 
 ## Flow Providers: [Non-custodial Wallets](https://github.com/onflow/flip-fest/issues/28)
 
-> **Winner: Congratulations to the Zaycodes!** :tada:
+> **Winner: Congratulations to the Zaycodes!** 🏆
 
 ### Issue Summary
 
@@ -237,7 +237,7 @@ Create a non-custodial FCL compatiable wallet.
 
 ## Playground Feature: Improve the resource explorer [#29](https://github.com/onflow/flip-fest/issues/29)
 
-> **Winner: Congratulations to the Team Exponential!** :tada:
+> **Winner: Congratulations to the Team Exponential!** 🏆
 
 ### Issue Summary
 
@@ -247,7 +247,7 @@ In the playground, the resource explorer is the tab the shows the resources insi
 
 ## JS Testing Feature: [Multiple return values from interaction](https://github.com/onflow/flip-fest/issues/30)
 
-> **Winner: Congratulations to the Team Exponential!** :tada:
+> **Winner: Congratulations to the Team Exponential!** 🏆
 
 ### Issue Summary
 
@@ -257,7 +257,7 @@ The JS Testing Framework has two functions: sendTransaction and executeScript th
 
 ## Improve Existing SDK: [Python](https://github.com/onflow/flip-fest/issues/46)
 
-> **Winner: Congratulations to the barekati!** :tada:
+> **Winner: Congratulations to the barekati!** 🏆
 
 ### Issue Summary
 
@@ -267,7 +267,7 @@ Improve the Python SDK to meet the `onflow/sdks` guidelines.
 
 ## Playground: [Fix client-side errors in the playground frontend](https://github.com/onflow/flip-fest/issues/58)
 
-> **Winner: Congratulations to the hichana!** :tada:
+> **Winner: Congratulations to the hichana!** 🏆
 
 ### Issue Summary
 

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -20,6 +20,19 @@ Here are the list of winning submissions in the New Tools category. Congratualti
 ### [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
 
 > **Winner: Congratulations to the flippers!** 🏆
+<a href="https://github.com/bartolomej">@bartolomej </a>
+<br />
+<a href="https://github.com/jgololicic">@jgololicic </a>
+<br />
+<a href="https://github.com/monikaxh">@monikaxh </a>
+<br />
+<a href="https://github.com/blockpilabs">@blockpilabs </a>
+<br />
+
+
+
+
+
 
 #### Challenge Summary 
 
@@ -30,6 +43,9 @@ Build a graphical user interface (GUI) that simplifies the network state into vi
 ### [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
 
 > **Winner: Congratulations to chris615_dad2 (chriswayoub)!** 🏆
+<a href="https://github.com/chriswayoub">@chriswayoub </a>
+
+
 
 #### Challenge Summary 
 
@@ -277,6 +293,12 @@ Our FLIP fiest contributers have started the conversation around 2 very importan
 ### [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
 
 > **Winner: Congratulations to the Non Fungibles!** 🏆
+<a href="https://github.com/bjartek">@bjartek </a><br/>
+<a href="https://github.com/bluesign ">@bluesign </a><br />
+<a href="https://github.com/briandilley">@briandilley </a><br />
+
+
+
 
 #### Challenge Summary 
 

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -2,6 +2,16 @@
 title: FLIP fest Winners!
 ---
 
+FLIP (Flow Improvement Proposals) are a way for Flow developers and users to provide direct feedbacl 
+to the Flow team about the improvements thye would like to see in Flow.
+
+FLIP Fest was conducted over 3 months with over 100 developers participating in working on issues determined by
+the Flow team and the community for reward bounties
+provided by Flow!
+
+The following is a list of the winning projects, their respective developers, and links to their FLIP 
+contribution Github repositories.
+
 ## New Tools
 
 ### [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
@@ -12,112 +22,6 @@ title: FLIP fest Winners!
 
 Build a graphical user interface (GUI) that simplifies the network state into visual elements, allows for simple interactions, and is optimized for debugging and inspecting the Flow blockchain state.
 
-<table style="width: 100%;">
-  <tbody>
-    <tr>
-      <th>Team Name</th>
-      <th align="center">Github Username(s)</th>
-      <th align="center">Milestones Completed</th>
-      <th align="center">Demo/Repo/Final PR</th>
-    </tr>
-    <tr>
-      <td><i>flippers</i></td>
-      <td align="left">
-        <ul>
-            <li> <a href="https://github.com/bartolomej"> bartolomej </a></li>
-            <li><a href="https://github.com/monikaxh"> monikaxh </a></li>
-            <li><a href="https://github.com/jgololicic"> jgololicic </a></li>
-        </ul>
-      </td>
-      <td align="right">4/4</td>
-      <td align="left">
-        <ul>
-            <li> <a href="https://flowser.dev"> Flowser Project Website </a></li>
-            <li><a href="https://github.com/onflowser/flowser"> Flowser Repo </a></li>
-            <li><a href="https://www.youtube.com/watch?v=yMs5awvGnlY"> Video Demo </a></li>
-        </ul>
-     </td>
-     </tr>
-  </tbody>
-</table>
-
-<table>
-    <tbody>
-        <tr>
-            <th align="center">Milestone Submission Rewards</th>
-            <th align="center">Winning Submission Rewards</th>
-            <th align="center">Bonus Submission Rewards</th>
-            <th align="center">Total Team Payout</th>
-        </tr>
-        <tr>
-            <td >$8,750</td>
-            <td >$50,000</td>
-            <td >N/A</td>
-            <td >$58,750</td>
-        </tr>
-    </tbody>
-</table>
-
-#### Payout summary
-
-<table>
-  <tbody>
-    <tr>
-      <th>Team Name</th>
-      <th align="center">Github Username</th>
-      <th align="center">% Allocation</th>
-      <th align="center">Total Reward Amount </th>
-      <th align="center">FLOW Amount</th>
-    </tr>
-    <tr>
-      <td>
-        <i>flippers</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/bartolomej"> bartolomej </a>
-      </td>
-      <td align="right">36.5%</td>
-      <td align="right">$21,444</td>
-      <td align="right">TBD</td>
-    </tr>
-    <tr>
-      <td>
-        <i>flippers</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/jgololicic"> jgololicic </a>
-      </td>
-      <td align="right">45.5%</td>
-      <td align="right">$26,731</td>
-      <td align="right">TBD</td>
-    </tr>
-    <tr>
-      <td>
-        <i>flippers</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/monikaxh"> monikaxh </a>
-      </td>
-      <td align="right">18%</td>
-      <td align="right">$10,575</td>
-      <td align="right">TBD</td>
-    </tr>
-    <tr>
-      <td>
-        <i>blockpi</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/blockpilabs"> blockpilabs </a>
-      </td>
-      <td align="right">100%</td>
-      <td align="right">$250</td>
-      <td align="right">TBD</td>
-    </tr>
-  </tbody>
-</table>
-
-
-
 ---
 
 ### [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
@@ -127,103 +31,6 @@ Build a graphical user interface (GUI) that simplifies the network state into vi
 #### Challenge Summary 
 
 When an event occurs, the application will update its internal state (e.g. a database) or notify its users of the on-chain activity. Many teams have integrated event tracking systems directly into their application infrastructure, but this is a common enough problem that it warrants a simple and general-purpose solution that can serve all teams.
-
-<table style="width: 100%;">
-  <tbody>
-    <tr>
-      <th>Team Name</th>
-      <th align="center">Github Username(s)</th>
-      <th align="center">Milestones Completed</th>
-      <th align="center">Demo/Repo/Final PR</th>
-    </tr>
-    <tr>
-        <td>
-        <i>chris615_dad2 </i>
-        </td>
-        <td align="left">
-            <ul>
-                <li>
-                <a href="https://github.com/chriswayoub"> chriswayoub </a>
-                </li>
-            </ul>
-        </td>
-        <td align="right">4/4</td>
-        <td align="left">
-        <ul>
-            <li>
-            <a href="https://github.com/onflow/flip-fest/tree/main/submissions/issue-15/milestone-4/pratik1719_a2eb9">
-                Last PR
-            </a>
-            </li>
-            <li>
-            <a href="https://github.com/rayvin-flow/flow-scanner">
-                Flow Scanner Service
-            </a>
-            </li>
-            <li>
-            <a href="https://github.com/rayvin-flow/flow-scanner-lib">
-                Flow Scanner Library
-            </a>
-            </li>
-        </ul>
-        </td>
-    </tr>
-  </tbody>
-</table>
-
-<table>
-  <tbody>
-    <tr>
-      <th align="center">Milestone Submission Rewards</th>
-      <th align="center">Winning Submission Rewards</th>
-      <th align="center">Bonus Submission Rewards</th>
-      <th align="center">Total Team Payout</th>
-    </tr>
-    <tr>
-        <td align="right">$8,750</td>
-        <td align="right">$0</td>
-        <td align="right">$25,000</td>
-        <td align="right">$33,750</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-<table>
-  <tbody>
-    <tr>
-      <th>Team Name</th>
-      <th align="center">Github Username</th>
-      <th align="center">% Allocation</th>
-      <th align="center">Total Reward Amount (USD) </th>
-      <th align="center">Flow Amount</th>
-    </tr>
-    <tr>
-      <td>
-        <i>chris615_dad2</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/chriswayoub"> chriswayoub </a>
-      </td>
-      <td align="right">100%</td>
-      <td align="right">$58,750</td>
-      <td align="right">TBD</td>
-    </tr>
-    <tr>
-      <td>
-        <i>pratik1719_a2eb</i>
-      </td>
-      <td align="left">
-        <a href="https://github.com/prpatel05"> prpatel05 </a>
-      </td>
-      <td align="right">100%</td>
-      <td align="right">$33,750</td>
-      <td align="right">TBD</td>
-    </tr>
-  </tbody>
-</table>
-
-
 
 ---
 

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -14,6 +14,9 @@ contribution Github repositories.
 
 ## New Tools
 
+Building on a platform like Flow is impossible without the right tools. And who better to build them than our users, who are working closely with Flow every day. 
+Here are the list of winning submissions in the New Tools category. Congratualtions!
+
 ### [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
 
 > **Winner: Congratulations to the flippers!** 🏆
@@ -267,6 +270,9 @@ The VS Code extension architecture could be improved so the extension becomes li
 ---
 
 ## New Standards
+
+The Flow protocol needs a solid set of standards to help developers and users understand the protocol and how to use it.
+Our FLIP fiest contributers have started the conversation around 2 very important new stardards for Flow.
 
 ### [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
 

--- a/docs/content/winners.mdx
+++ b/docs/content/winners.mdx
@@ -1,0 +1,274 @@
+# FLIP Fest Winners
+
+---
+
+## New Tool: [Block explorer GUI](https://github.com/onflow/flip-fest/issues/2)
+
+> **Winner: Congratulations to the Flippers!** 
+
+### Issue Summary
+
+Build a graphical user interface (GUI) that simplifies the network state into visual elements, allows for simple interactions, and is optimized for debugging and inspecting the Flow blockchain state.
+
+
+--- 
+
+## VS Code Extension: [Architecture improvements](https://github.com/onflow/flip-fest/issues/3)
+
+### Issue Summary
+
+The VS Code extension architecture could be improved so the extension becomes lighter and only handles the communication with the language server and the UI.
+
+---
+
+## CryptoDappy Feature: [NFT Marketplace](https://github.com/onflow/flip-fest/issues/5)
+
+> **Winner: Congratulations to phillip62_a774 (ph0ph0)!** :tada:
+
+### Issue Summary
+
+We want to give users the experience to list their Dappies (NFTs) for sale in order to sell them to other buyers, and give buyers a chance to purchase Dappies of other users.
+
+---
+
+## CryptoDappy Feature: [localization (I18n) solution](https://github.com/onflow/flip-fest/issues/6)
+
+> **Winner: Congratulations to nagato1_c511 (knagato)!** :tada:
+
+### Issue Summary
+
+Community members have already published some translated documents (e.g. Vietnamese version), but the basic functionality of changing the language on the Learning Hub has not been implemented yet.
+
+---
+
+## Dev Wallet Feature: [Improve OpenID implementation](https://github.com/onflow/flip-fest/issues/10)
+
+### Issue Summary
+
+Dapps should be able to define and request user information (as per OpenID Standards) from FCL compatible wallet providers so that they can associate the account address with identity fields.
+
+---
+
+
+## CLI Feature: [Launch FCL development wallet](https://github.com/onflow/flip-fest/issues/11)
+
+> **Winner: Congratulations to bluesign!** :tada:
+
+### Issue Summary
+
+This effort proposes bundling the dev wallet server as part of the emulator, and starting the wallet service alongside the emulator when working locally, removing the necessity for users to configure and run the dev wallet docker container manually.
+
+---
+
+## Emulator Feature: [Report gas used](https://github.com/onflow/flip-fest/issues/12)
+
+> **Winner: Congratulations to nagato1_c511 (avcdsld)!** :tada:
+
+### Issue Summary
+
+There should be a way to see transaction gas (computation) usage.
+
+---
+
+## CLI Feature: [Hot Command](https://github.com/onflow/flip-fest/issues/14)
+
+> **Winner: Congratulations to saksham214_1499 (sakshamb2113)!** :tada:
+
+### Issue Summary
+
+The flow CLI should be customized to provide easy access to common commands.
+
+---
+
+## New Tool: [Events indexing service](https://github.com/onflow/flip-fest/issues/15)
+
+> **Winner: Congratulations to chris615_dad2 (chriswayoub)!** :tada:
+
+### Issue Summary
+
+When an event occurs, the application will update its internal state (e.g. a database) or notify its users of the on-chain activity. Many teams have integrated event tracking systems directly into their application infrastructure, but this is a common enough problem that it warrants a simple and general-purpose solution that can serve all teams.
+
+
+---
+
+## New Standard: [NFT metadata](https://github.com/onflow/flip-fest/issues/16)
+
+> **Winner: Congratulations to the Non Fungibles!** :tada:
+
+### Issue Summary
+
+The current Flow NFT interface, however, does not include a metadata standard that allows these representations to flourish. NFTs should be able to include structured data, images, videos and other types of data.
+
+---
+
+## New Standard: [Decentralized identifiers (DIDs) on Flow](https://github.com/onflow/flip-fest/issues/17)
+
+> **Winner: Congratulations to the mwufi!** :tada:
+
+### Issue Summary
+
+Flow could benefit from dedicated DID infrastructure for interoperating Flow identities with services outside of Flow, such as decentralized data storage and credential verification systems.
+
+---
+
+## Playground Feature: [Markdown READMEs](https://github.com/onflow/flip-fest/issues/18)
+
+> **Winner: Congratulations to Team Exponential!** :tada:
+
+### Issue Summary
+
+The goal of this task is to add a feature to the playground that allows developers to add a written description to their projects, similar to README files in git repositories.
+
+---
+
+## New Tool: [Add Cadence support for IntelliJ Platform](https://github.com/onflow/flip-fest/issues/19)
+
+> **Winner: Congratulations to freeflowers!** :tada:
+
+### Issue Summary
+
+Goal is to integrate basic Cadence editing features into the IntelliJ Platform, an IDE framework developed by JetBrains. Although IntelliJ itself is a Java editor, it is possible to write a plugin that adds Cadence language support to all IntelliJ-based editors (e.g. PyCharm, WebStorm).
+
+---
+
+## New Tool: [Build a Flow .NET SDK](https://github.com/onflow/flip-fest/issues/20)
+
+> **Winner: Congratulations to tyronbrand!** :tada:
+
+### Issue Summary
+
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
+
+---
+
+## New Tool: [Build a Flow Swift SDK](https://github.com/onflow/flip-fest/issues/20)
+
+> **Winner: Congratulations to lmcmz!** :tada:
+
+### Issue Summary
+
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
+
+---
+
+## New Tool: [Build a Flow Rust SDK](https://github.com/onflow/flip-fest/issues/20)
+
+> **Winner: Congratulations to fee-1-dead!** :tada:
+
+### Issue Summary
+
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
+
+---
+
+## New Tool: [Build a Flow Ruby SDK](https://github.com/onflow/flip-fest/issues/20)
+
+> **Winner: Congratulations to nduplessis!** :tada:
+
+### Issue Summary
+
+We are looking for teams interested in building and maintaining SDKs for Flow to make it easier for a broad range of developers to interact with the blockchain. Build a SDK to the `onflow/sdks` guidelines in a language from the list on the issue.
+
+---
+
+## Playground Feature: [Multiple contracts per account](https://github.com/onflow/flip-fest/issues/21)
+
+> **Winner: Congratulations to squidplay!** :tada:
+
+### Issue Summary
+
+Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
+
+---
+
+## CLI Feature: [State management](https://github.com/onflow/flip-fest/issues/22)
+
+> **Winner: Congratulations to the Non Fungibles!** :tada:
+
+### Issue Summary
+
+Flow developers use the playground to learn, experiment, and share Cadence code. The current playground model only supports a single account to have a single contract. We want to expand this feature to hold multiple contracts per account.
+
+---
+
+## Non-React FCL Usage: [Dapp example](https://github.com/onflow/flip-fest/issues/23)
+
+> **Winner: Congratulations to the Enouvo!** :tada:
+
+### Issue Summary
+
+While using FCL is possible in non-react example, we do not have many examples in the community of this usage. There are some issues with installing the FCL package directly due to packages used to support GRPC.
+
+---
+
+## FCL Feature: [Calculate the transaction hash](https://github.com/onflow/flip-fest/issues/24)
+
+> **Winner: Congratulations to the nagato1_c511!** :tada:
+
+### Issue Summary
+
+Get the transaction hash before it's sent to the blockchain for FCL.
+
+---
+
+## Emulator Feature: [Bootstrap with default contracts](https://github.com/onflow/flip-fest/issues/27)
+
+> **Winner: Congratulations to the FlashyTigers!** :tada:
+
+### Issue Summary
+
+The emulator should be able to deploy contracts when it starts up. For Example:
+
+- NFT Marketplace
+- NFT
+- FUSD
+
+---
+
+## Flow Providers: [Non-custodial Wallets](https://github.com/onflow/flip-fest/issues/28)
+
+> **Winner: Congratulations to the Zaycodes!** :tada:
+
+### Issue Summary
+
+Create a non-custodial FCL compatiable wallet.
+
+---
+
+## Playground Feature: Improve the resource explorer [#29](https://github.com/onflow/flip-fest/issues/29)
+
+> **Winner: Congratulations to the Team Exponential!** :tada:
+
+### Issue Summary
+
+In the playground, the resource explorer is the tab the shows the resources inside each account. It is hidden initially and only shows up once you interact with an account's storage. But even then, it only shows up after you click an account, which usually decouples the view a transaction that updates the stored resources.
+
+---
+
+## JS Testing Feature: [Multiple return values from interaction](https://github.com/onflow/flip-fest/issues/30)
+
+> **Winner: Congratulations to the Team Exponential!** :tada:
+
+### Issue Summary
+
+The JS Testing Framework has two functions: sendTransaction and executeScript that currently return a single result from their execution. It does not have a good way of handling errors that should be caught and processed. This can cause issues with multiple interactions called in succession.
+
+---
+
+## Improve Existing SDK: [Python](https://github.com/onflow/flip-fest/issues/46)
+
+> **Winner: Congratulations to the barekati!** :tada:
+
+### Issue Summary
+
+Improve the Python SDK to meet the `onflow/sdks` guidelines.
+
+---
+
+## Playground: [Fix client-side errors in the playground frontend](https://github.com/onflow/flip-fest/issues/58)
+
+> **Winner: Congratulations to the hichana!** :tada:
+
+### Issue Summary
+
+The Flow Playground frontend app throws a number of console errors in product. Those errors shouldn't be there.

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -239,7 +239,7 @@ const sources = [
         "docs/get-collections.md",
         "docs/get-status.md",
         "docs/security.md",
-        "docs/start-emulator.md"
+        "docs/start-emulator.md",
         "docs/complex-transactions.md",
         "docs/decode-keys.md",
         "docs/manage-configuration.md",
@@ -355,14 +355,8 @@ const sections = [
     sidebarAlwaysExpanded: true,
     sidebar: {
       null: ["[Home](/)"],
-      "Flow CLI": [
-        "docs/index",
-        "docs/install"
-      ],
-      Keys: [
-        "docs/generate-keys",
-        "docs/decode-keys"
-      ],
+      "Flow CLI": ["docs/index", "docs/install"],
+      Keys: ["docs/generate-keys", "docs/decode-keys"],
       Accounts: [
         "docs/get-accounts",
         "docs/create-accounts",
@@ -397,7 +391,7 @@ const sections = [
         "docs/get-collections",
         "docs/get-status"
       ],
-      "Utils": [
+      Utils: [
         "docs/project-app",
         "docs/signature-generate",
         "docs/signature-verify"


### PR DESCRIPTION
Closes: #710 

## Description

Add content from https://github.com/onflow/flip-fest/blob/main/winners.md to docs site.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
