### PR TITLE
add reference for service account addresses

### DIFF
--- a/docs/content/core-contracts/service-account.mdx
+++ b/docs/content/core-contracts/service-account.mdx
@@ -9,7 +9,7 @@ There are two contracts deployed to the service account:
 - `FlowServiceAccount` tracks transaction fees, deployment permissions, and provides 
 some convenience methods for Flow Token operations.
 
-Source: [FlowServiceAccount.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc
+Source: [FlowServiceAccount.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc)
 
 - `FlowStorageFees` defines and implements the rules and methods for how accounts pay for their storage usage.
 

--- a/docs/content/core-contracts/service-account.mdx
+++ b/docs/content/core-contracts/service-account.mdx
@@ -1,0 +1,22 @@
+---
+title: Service Account Contracts
+sidebar_title: Service Account
+---
+
+The service account is the account that manages the core protocol requirements of Flow.
+There are two contracts deployed to the service account:
+
+- `FlowServiceAccount` tracks transaction fees, deployment permissions, and provides 
+some convenience methods for Flow Token operations.
+
+Source: [FlowServiceAccount.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc
+
+- `FlowStorageFees` defines and implements the rules and methods for how accounts pay for their storage usage.
+
+Source: [FlowStorageFees.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowStorageFees.cdc)
+
+| Network  | Contract Address     |
+| -------- | -------------------- |
+| Emulator | `0xf8d6e0586b0a20c7` |
+| Testnet  | `0x8c5303eaa26202d6` |
+| Mainnet  | `0xe467b9dd11fa00df` |

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -515,6 +515,7 @@ const sections = [
         "core-contracts/fungible-token",
         "core-contracts/flow-token",
         "core-contracts/flow-fees",
+        "core-contracts/service-account",
         "core-contracts/staking-contract-reference",
         "core-contracts/epoch-contract-reference"
       ],


### PR DESCRIPTION
## Description

Adds a reference page for the addresses of the service account contracts on the emulator, testnet, and mainnet

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
