### PR TITLE
Added missing doc updates for ExecutionDataID

### DIFF
--- a/docs/content/access-api.md
+++ b/docs/content/access-api.md
@@ -1095,6 +1095,7 @@ message ExecutionResult {
   bytes block_id
   repeated Chunk chunks
   repeated ServiceEvent service_events
+  bytes execution_data_id  
 }
 ```
 
@@ -1104,6 +1105,7 @@ message ExecutionResult {
 | block_id           | ID of the block this execution result corresponds to |
 | chunks             | Zero or more chunks                                  |
 | service_events     | Zero or more service events                          |
+| execution_data_id  | Root ID of the Execution Data blob tree              |
 
 
 ### Chunk

--- a/docs/content/access-api.md
+++ b/docs/content/access-api.md
@@ -1095,7 +1095,6 @@ message ExecutionResult {
   bytes block_id
   repeated Chunk chunks
   repeated ServiceEvent service_events
-  bytes execution_data_id  
 }
 ```
 
@@ -1105,7 +1104,6 @@ message ExecutionResult {
 | block_id           | ID of the block this execution result corresponds to |
 | chunks             | Zero or more chunks                                  |
 | service_events     | Zero or more service events                          |
-| execution_data_id  | Root ID of the Execution Data blob tree              |
 
 
 ### Chunk

--- a/openapi/go-client-generated/docs/ExecutionResult.md
+++ b/openapi/go-client-generated/docs/ExecutionResult.md
@@ -7,7 +7,6 @@ Name | Type | Description | Notes
 **BlockId** | **string** |  | [default to null]
 **Events** | [**[]Event**](Event.md) |  | [default to null]
 **Links** | [***Links**](Links.md) |  | [optional] [default to null]
-**ExecutionDataID** | **string**  |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/openapi/go-client-generated/docs/ExecutionResult.md
+++ b/openapi/go-client-generated/docs/ExecutionResult.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **BlockId** | **string** |  | [default to null]
 **Events** | [**[]Event**](Event.md) |  | [default to null]
 **Links** | [***Links**](Links.md) |  | [optional] [default to null]
+**ExecutionDataID** | **string**  |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
We found that ExecutionDataID was newly in the code but not updated in the docs. This fixes that omission
