### PR TITLE
schedule clarification

### DIFF
--- a/docs/content/staking/schedule.mdx
+++ b/docs/content/staking/schedule.mdx
@@ -27,12 +27,13 @@ when one epoch ends and the next epoch begins, marking a possible change in the 
 <Callout type="info">
 
 The exact timing of the epoch end is influenced by the number of blocks proposed during the epoch. 
-**All quoted epoch end times are estimates and subject to some variance**. See [Epoch Preparation Protocol](/staking/epoch-preparation/#epoch-length) for details. 
+**All quoted epoch end times are estimates and subject to some variance (up to a few hours)**. See [Epoch Preparation Protocol](/staking/epoch-preparation/#epoch-length) for details. 
 
 </Callout>
 
+**Staking Operations will be disabled for the last day of an epoch**, typically around 12:00pm (7:00pm UTC) on Tuesday every, until the next day around the same time.
 
-**Epoch Switchovers will happen at approximately 12:00 pm PT on Wednesday (7:00 pm UTC)** every week. 
+**Epoch Switchovers will happen around 12:00 pm PT on Wednesday (7:00 pm UTC)** every week. 
 Please note exact epoch ending time vary based on the performance of the network & all staking operations that interact with staked tokens will be processed by the protocol at the start of each epoch. 
 
 ## Rewards


### PR DESCRIPTION
## Description

Adds a clarification to the beginning of epochs docs to remind that staking operations will be disabled.

Mostly just need to do another docs site redeploy to pick up the updated marketplace tutorial changes from https://github.com/onflow/cadence/pull/1412