### PR TITLE
Adjust chainID type to native string

### DIFF
--- a/protobuf/flow/entities/block_header.proto
+++ b/protobuf/flow/entities/block_header.proto
@@ -18,5 +18,5 @@ message BlockHeader {
   bytes parent_voter_sig_data = 8;
   bytes proposer_id = 9;
   bytes proposer_sig_data = 10;
-  bytes chain_id = 11;
+  string chain_id = 11;
 }


### PR DESCRIPTION
small miss, `String([]byte)` cast doesn't compensate for the forward conversion