### PR TITLE
Remove Cadence developer docs

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -335,10 +335,8 @@ const sections = [
         "[Cadence Anti-Patterns](/cadence/anti-patterns/)",
         "[msg․sender Considered Harmful](/cadence/msg-sender/)",
         "[Measuring Time In Cadence](/cadence/measuring-time/)",
-        "[Subtyping](/cadence/subtyping/)",
         "[Migration Guide](/cadence/migration-guide/)",
         "[JSON-Cadence Data Interchange Format](/cadence/json-cadence-spec/)",
-        "[Syntax Highlighting](/cadence/syntax-highlighting/)"
       ],
       Tutorial: [
         "docs/tutorial/01-first-steps",


### PR DESCRIPTION
## Description

The subtyping and syntax highlighting documentation is aimed at developers working on Cadence or tooling for it, not at users of Cadence. 

Remove the entries to avoid confusion for Cadence users.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
