### PR TITLE
Add tab for new Discovery docs page

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -471,7 +471,8 @@ const sections = [
         "[Proving Account Ownership](/fcl/reference/proving-authentication/)",
         "[Scripts](/fcl/reference/scripts/)",
         "[Transactions](/fcl/reference/transactions/)",
-        "[User Signatures](/fcl/reference/user-signatures/)"
+        "[User Signatures](/fcl/reference/user-signatures/)",
+        "[Wallet Discovery](/fcl/reference/discovery/)"
       ],
       Changelogs: [
         "[@onflow/fcl](/fcl/packages/fcl/CHANGELOG)",


### PR DESCRIPTION
Closes: [883](https://github.com/onflow/flow/issues/883)

## Description

Add a new tab to docs for new FCL Discovery page.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
