### PR TITLE
Kitty Items: typo in navigation & float nft info

### DIFF
--- a/docs/content/kitty-items/modify.md
+++ b/docs/content/kitty-items/modify.md
@@ -191,6 +191,7 @@ transaction {
 
   }
 
+  // the FLOAT NFT secret code is: witty-kitty
   execute {}
 }
 ```

--- a/docs/content/kitty-items/update.md
+++ b/docs/content/kitty-items/update.md
@@ -138,7 +138,9 @@ Events:
 
 As indicated, the transaction was sealed and you are ready to mint your new KittyItems NFT on the testnet!
 
-**Congratulation on completing this tutorial**
+**🎉 Congratulations on completing this tutorial! Because you made it to the very end, we're rewarding you with a unique [FLOAT NFT](https://floats.city/andrea.find/event/198577460)!**
+
+> **Important**: To claim your NFT, open [this FLOAT event](https://floats.city/andrea.find/event/198577460). You will be asked to connect a wallet. Once done, you need to enter a **secret code**. Open the `add_nft_images_for_new_kind.cdc` file you created in [this previous step](/kitty-items/modify/#create-a-transaction-to-update-the-list-of-images-for-your-new-kind). Locate the comment before `execute{}`. Use this code to claim your NFT 🤫
 
 To summarize, you should now understand how to ...
 

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -692,7 +692,7 @@ const sections = [
         "kitty-items/update",
         "kitty-items/next-steps",
       ],
-      "NFT Matketplace Guide": [
+      "NFT Marketplace Guide": [
         "nft-marketplace/index",
         "nft-marketplace/building-blocks",
         "nft-marketplace/handling-accounts",


### PR DESCRIPTION
This fixes a typo in the kitty items navigation

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
