### PR TITLE
Add github actions for getting diff & calling refresh

### DIFF
--- a/.github/workflows/call-refresh-doc.yml
+++ b/.github/workflows/call-refresh-doc.yml
@@ -3,7 +3,7 @@ name: call-refresh-doc
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   compare:

--- a/.github/workflows/call-refresh-doc.yml
+++ b/.github/workflows/call-refresh-doc.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compare
     if: ${{ needs.compare.outputs.all_modified_files != 0 }}
-    uses: onflow/flow/.github/workflows/refresh-doc.yml@main
+    uses: onflow/flow/.github/workflows/refresh-doc.yml@master
     with:
       contentPaths: ${{ needs.compare.outputs.all_modified_files }}
       repository: ${{ github.event.repository.name }}

--- a/.github/workflows/call-refresh-doc.yml
+++ b/.github/workflows/call-refresh-doc.yml
@@ -1,0 +1,53 @@
+# This workflow is stored and called from each repository that contains documentation files
+name: call-refresh-doc
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v19
+      with:
+        files: |
+          docs/**/*.md
+          docs/**/*.mdx
+
+    # --- Log all diff info --- 
+    - name: Log the files commit SHA if any md/mdx files have diffs
+      continue-on-error: true
+      if: steps.changed-files.outputs.any_modified == 'true'
+      run: |
+        for file in ${{ steps.changed-files.outputs.all_modified_files }}; do
+          echo "$file was modified" with the commit ${{ github.sha }}
+        done
+        for file in ${{ steps.changed-files.outputs.added_files }}; do
+          echo "$file was added"
+        done
+        for file in ${{ steps.changed-files.outputs.deleted_files }}; do
+          echo "$file was deleted"
+        done
+        for file in ${{ steps.changed-files.outputs.all_modified_files }}; do
+          echo "$file was modified"
+        done
+    outputs: 
+      all_modified_files: ${{ steps.changed-files.outputs.all_modified_files }}
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+
+  # --- If modified, call refresh --- 
+  call-refresh-workflow-passing-data:
+    runs-on: ubuntu-latest
+    needs: compare
+    if: ${{ needs.compare.outputs.all_modified_files != 0 }}
+    uses: onflow/flow/.github/workflows/refresh-doc.yml@main
+    with:
+      contentPaths: ${{ needs.compare.outputs.all_modified_files }}
+      repository: ${{ github.event.repository.name }}
+      commitSha: ${{ github.sha }}
+      

--- a/.github/workflows/refresh-doc.yml
+++ b/.github/workflows/refresh-doc.yml
@@ -1,0 +1,28 @@
+# This workflow is contained in a centralized repository (onflow/flow), and is called when there are changes pushed in any documentation repository
+name: refresh-doc
+on:
+  workflow_call:
+    inputs:
+      contentPaths:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+      commitSha:
+        required: true
+        type: string
+
+jobs:
+  reusable_refresh_job:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📞 Call refresh endpoint
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: 'https://flow-docs-staging.fly.dev/action/refresh'
+        method: 'POST'
+        data: '{ "auth":"authToken", "repo":"${{ inputs.repository }}", "commitSha":"${{ inputs.commitSha }}", "contentPaths":["${{ inputs.contentPaths }}"] }'
+        ignoreStatusCodes: '404'
+        
+       


### PR DESCRIPTION
Closes: [#67](https://github.com/onflow/next-docs-v1/issues/67)

## Description
Created Github Actions in 2 workflows: 1. call-refresh-doc, 2. refresh-doc. First workflow parses the documentation for diffs. If there are diffs, it calls the refresh endpoint in the second workflow.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Link to documentation site repo: https://github.com/onflow/next-docs-v1
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
