### PR TITLE
Rebrand Bison Trails to Coinbase Cloud

### DIFF
--- a/nodeoperators/NodeOperatorList.md
+++ b/nodeoperators/NodeOperatorList.md
@@ -18,41 +18,6 @@
 | Accomplice | Verification | 79949f163dac6b72ab72c1d12b9677d71dd9367f7331d59425b485050c8712d9
 | Alxo | Verification | f7422f2d3296ede4d1efb36ec55e3fd93702c061f7ee627881f0b3007beff2ed
 | Artemis | Verification | a67ca1afd47c58358c656dffa2e5585d80b01371866e5634b68dcbab090b9b6f 
-| Bison Trails | Collection | 48ba5aabeaf1a7c1bc6a96b20c8e9f6cbe7f6b3c77faec3b77fa66a630abf8c7
-| Bison Trails | Consensus | a65461e68eae80c9bd9d8edc81857c7d2cd83ba9992433c468e9ef6515d32006
-| Bison Trails | Consensus | 022699aba098bce3eb3a8709f29feafa9793f65de7d24d37a46310d788cbcc74
-| Bison Trails | Consensus | 07e3017f5327ed10b7cfa0e3b3f7dc97df8f1ce2cc9d9be25e7aef00e932a691
-| Bison Trails | Consensus | 10ea3b6872e187b3835bf57f6a9597738aa6b396c03c1549f4cdac789ae27e8e
-| Bison Trails | Consensus | 166d1b52831da570fb37f0d85ded5d164937bc7ae976a6037bc33a77c3113735
-| Bison Trails | Consensus | 1a697950a4843dc67bbd34cbb0016854e64e66f088b54447beeea6999ff7641d
-| Bison Trails | Consensus | 2040bd128455e833c0968bf51c0a2eb4d05399e1ab5ac323d38170b975688bea
-| Bison Trails | Consensus | 245efcb37ebdb2966bafc0112dd86bc1f5e1d3ffa70b66887eaeb3a667b3f477
-| Bison Trails | Consensus | 3890fd0a26c0272807b731d0dda0eb15bfa5183533032303e062e9206e9f4e69
-| Bison Trails | Consensus | 490e27d1d5335f20473871f06324f4cff862d4fc22c4af7ab87574292764c518
-| Bison Trails | Consensus | 492bab4b9cb02c97bd2b03859640002e8d81eb2bc33e723ae8fabcc64f30d653
-| Bison Trails | Consensus | 54abbaea844dfc3c6cc0f58f0170783d6d01bef578761113558c4321a3e1a0df
-| Bison Trails | Consensus | 7133b78ac9e788c428a354f2f96b5cc8109123425a88cc75d729bf5adfd0a25d
-| Bison Trails | Consensus | 76a117e9635097b8a7ef6ac867f1525a76854b7e42b38075e3b422bd73e5dd2f
-| Bison Trails | Consensus | 7db974a1aa956a2693ae0bafc357e8b220d30c8a0c64213badfc603e8b911d9a
-| Bison Trails | Consensus | 8d16bacfd9854ccdc0496ec2b99fc9dab94e5810686bd4df2bd956a8a8f81fa0
-| Bison Trails | Consensus | 8f4d09dae7918afbf62c48fa968a9e8b0891cee8442065fa47cc05f4bc9a8a91
-| Bison Trails | Consensus | 95ffacf0c05757cff71a4ee49e025d5a6d1103a3aa7d91253079e1bfb7c22458
-| Bison Trails | Consensus | a01657135399d9817a1b9933c7663077ef9e376fbe72bf56d687b23d75c2f76c
-| Bison Trails | Consensus | a1bd45dbbf9077ce0ada513e2055ab4276ff81891936b0b8374617eee50c6987
-| Bison Trails | Consensus | a494a83f3eee8d95c49931a26483907aabe7bf8d6325a777b9033734756614f1
-| Bison Trails | Consensus | adbd46d6628bb41e84635f436b3411da4dde2d80854c1b6ead3373cc962d4be6
-| Bison Trails | Consensus | af8450d3906c7c3af8981736bbfbc67da78d71bee82c6f301f7656bc62815945
-| Bison Trails | Consensus | b38182167be80a81f7c7534da5c72cc6e59c0922e2aced43f8b01df3630cf788
-| Bison Trails | Consensus | b5e3cdbeb4986460b57a5a363789bb587eae7bff05589dcd122bcedc62be6664
-| Bison Trails | Consensus | b68dbd999fbf3084685833efdb6e65038f90d53992290919c0cb8332b6ac93bd
-| Bison Trails | Consensus | ccd5e456be83922268ee4a07841f7c6c2f009fac77b80828e08f7e7efd6e5278
-| Bison Trails | Consensus | e09a474478e44aed738b680d04eca770953468a80151a2491f90296009b0ee65
-| Bison Trails | Consensus | e2314f73ff8aa1fa7110b180b5e5d113898e56bc6b43f9e5c889a6bffebeec0e
-| Bison Trails | Consensus | e782fb8a9895251a82cb68b87d1306748775188c9fca97a9b91b444ddd5f7e11
-| Bison Trails | Consensus | f36176beb56175277ec31b77f51058a69ae1ebe9a13d990aa93f943d48793fd4
-| Bison Trails | Consensus | fdbe6cb2bc0e45671e977ba621746d113aaa7f045c5d3274addcd6141c8c765d
-| Bison Trails | Verification | b17280bf57adad0de648d827a7ccbe81c74cf6a9cc44af4778587b133747a2f9
-| Bison Trails | Execution | e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb
 | Bitcoin Louie | Verification | fffba108a52e4ca8f5d30658c3f03f47ad1cc13a0995435c0532336236813218
 | Blockchain at Berkeley | Verification | 8f8d77ba98d1606b19fce8f6d35908bfc29ea171c02879162f6755c05e0ca1ee
 | Blockchain Coalition/Block Venture | Verification | 16036263d71f64d65f84542e9f7678e578482a107b61e45b88759ebea2c7451d
@@ -67,6 +32,41 @@
 | Chainlayer | Consensus | 62de4fa4b6a05b8beb5868a5259caca4efa966aa0cb867fdd776c73abe9370ad
 | Chainlayer | Collection | 050dfd9898470c042e9190b8a9136122dee26dad438cf5b49307f55fe4dbcc98
 | Chainlayer | Verification | d4ffda5cbdea87f6464d37c7ab079d3f8589454d2de2b6bce1cc6c6f20829dc2
+| Coinbase Cloud | Collection | 48ba5aabeaf1a7c1bc6a96b20c8e9f6cbe7f6b3c77faec3b77fa66a630abf8c7
+| Coinbase Cloud | Consensus | 022699aba098bce3eb3a8709f29feafa9793f65de7d24d37a46310d788cbcc74
+| Coinbase Cloud | Consensus | 07e3017f5327ed10b7cfa0e3b3f7dc97df8f1ce2cc9d9be25e7aef00e932a691
+| Coinbase Cloud | Consensus | 10ea3b6872e187b3835bf57f6a9597738aa6b396c03c1549f4cdac789ae27e8e
+| Coinbase Cloud | Consensus | 166d1b52831da570fb37f0d85ded5d164937bc7ae976a6037bc33a77c3113735
+| Coinbase Cloud | Consensus | 1a697950a4843dc67bbd34cbb0016854e64e66f088b54447beeea6999ff7641d
+| Coinbase Cloud | Consensus | 2040bd128455e833c0968bf51c0a2eb4d05399e1ab5ac323d38170b975688bea
+| Coinbase Cloud | Consensus | 245efcb37ebdb2966bafc0112dd86bc1f5e1d3ffa70b66887eaeb3a667b3f477
+| Coinbase Cloud | Consensus | 3890fd0a26c0272807b731d0dda0eb15bfa5183533032303e062e9206e9f4e69
+| Coinbase Cloud | Consensus | 490e27d1d5335f20473871f06324f4cff862d4fc22c4af7ab87574292764c518
+| Coinbase Cloud | Consensus | 492bab4b9cb02c97bd2b03859640002e8d81eb2bc33e723ae8fabcc64f30d653
+| Coinbase Cloud | Consensus | 54abbaea844dfc3c6cc0f58f0170783d6d01bef578761113558c4321a3e1a0df
+| Coinbase Cloud | Consensus | 7133b78ac9e788c428a354f2f96b5cc8109123425a88cc75d729bf5adfd0a25d
+| Coinbase Cloud | Consensus | 76a117e9635097b8a7ef6ac867f1525a76854b7e42b38075e3b422bd73e5dd2f
+| Coinbase Cloud | Consensus | 7db974a1aa956a2693ae0bafc357e8b220d30c8a0c64213badfc603e8b911d9a
+| Coinbase Cloud | Consensus | 8d16bacfd9854ccdc0496ec2b99fc9dab94e5810686bd4df2bd956a8a8f81fa0
+| Coinbase Cloud | Consensus | 8f4d09dae7918afbf62c48fa968a9e8b0891cee8442065fa47cc05f4bc9a8a91
+| Coinbase Cloud | Consensus | 95ffacf0c05757cff71a4ee49e025d5a6d1103a3aa7d91253079e1bfb7c22458
+| Coinbase Cloud | Consensus | a01657135399d9817a1b9933c7663077ef9e376fbe72bf56d687b23d75c2f76c
+| Coinbase Cloud | Consensus | a1bd45dbbf9077ce0ada513e2055ab4276ff81891936b0b8374617eee50c6987
+| Coinbase Cloud | Consensus | a494a83f3eee8d95c49931a26483907aabe7bf8d6325a777b9033734756614f1
+| Coinbase Cloud | Consensus | a65461e68eae80c9bd9d8edc81857c7d2cd83ba9992433c468e9ef6515d32006
+| Coinbase Cloud | Consensus | adbd46d6628bb41e84635f436b3411da4dde2d80854c1b6ead3373cc962d4be6
+| Coinbase Cloud | Consensus | af8450d3906c7c3af8981736bbfbc67da78d71bee82c6f301f7656bc62815945
+| Coinbase Cloud | Consensus | b38182167be80a81f7c7534da5c72cc6e59c0922e2aced43f8b01df3630cf788
+| Coinbase Cloud | Consensus | b5e3cdbeb4986460b57a5a363789bb587eae7bff05589dcd122bcedc62be6664
+| Coinbase Cloud | Consensus | b68dbd999fbf3084685833efdb6e65038f90d53992290919c0cb8332b6ac93bd
+| Coinbase Cloud | Consensus | ccd5e456be83922268ee4a07841f7c6c2f009fac77b80828e08f7e7efd6e5278
+| Coinbase Cloud | Consensus | e09a474478e44aed738b680d04eca770953468a80151a2491f90296009b0ee65
+| Coinbase Cloud | Consensus | e2314f73ff8aa1fa7110b180b5e5d113898e56bc6b43f9e5c889a6bffebeec0e
+| Coinbase Cloud | Consensus | e782fb8a9895251a82cb68b87d1306748775188c9fca97a9b91b444ddd5f7e11
+| Coinbase Cloud | Consensus | f36176beb56175277ec31b77f51058a69ae1ebe9a13d990aa93f943d48793fd4
+| Coinbase Cloud | Consensus | fdbe6cb2bc0e45671e977ba621746d113aaa7f045c5d3274addcd6141c8c765d
+| Coinbase Cloud | Execution | e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb
+| Coinbase Cloud | Verification | b17280bf57adad0de648d827a7ccbe81c74cf6a9cc44af4778587b133747a2f9
 | Coinfund | Consensus | 5a4bff17941a73909472afe23f1ccdc59d7526f93b16b4e374bd8353f8b624b4
 | Coinfund | Consensus | b5702f80aa39f06ecdf4d6321bfe40f64e40b9b630085a42993f1b241bfcbf25
 | Coinfund | Consensus | d98755f4ae8bef3f372889c4d7010ca784ea6da46fdde63d27ee57b2bf5efdd7


### PR DESCRIPTION
## Description

Rebranding Bison Trails nodes to Coinbase Cloud due to the acquisition by Coinbase.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
