### PR TITLE
Opening up the alpha preview to the new dev portal

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -26,52 +26,24 @@ import {
 <h3>
   {" "}
   ⚡️
-  <TrackingLink href="/http-api/" eventName="Homepage_link_/http-api/_clicked">
-    Flow Access Node HTTP API
+  <TrackingLink target="_blank" href="https://developers.onflow.org" eventName="Homepage_link_/dev_portal_home/_clicked">
+    Preview our new Developer Portal
   </TrackingLink>
 </h3>
 
 <ul className="grid-item-list">
   <li>
-   The Flow access node API for REST clients. Usable with the <TrackingLink href="https://github.com/onflow/flow-emulator#configuration
-" eventName="Homepage_link_/flow-cli/_clicked">
-  Flow CLI (Emulator)
-</TrackingLink>
- {" "}
- and {" "}
-<TrackingLink href="https://github.com/onflow/fcl-js/blob/master/packages/sdk/CHANGELOG.md#0057-alpha1----2022-01-21
-" eventName="Homepage_link_/fcl/_clicked">
-  FCL (Flow Client Library)
-</TrackingLink>
-<br/>
-<br />
-
-<span>https://rest-testnet.onflow.org/v1/</span>
-<p>
-  Testnet:{" "}
-  <TrackingLink
-    event="Homepage*link*/http-api-testnet/\_clicked"
-    href="/http-api/"
-  >
-    View Documentation
+   With the growing number of developers, tools, and content in the Flow ecosystem, we are creating a new experience to 
+   help developers not only find and discover what they need, but also have new ways to connect and contribute with the community. We have opened up 
+   a preview of the new site in an alpha version and will be launching the full experience in July 2022. <br/>
+   <TrackingLink href="https://developers.onflow.org" eventName="Homepage_link_/dev_portal_home/_clicked">
+    Homepage
+  </TrackingLink> 
+  <br/>
+  <TrackingLink href="https://developers.onflow.org/getting-started" eventName="Homepage_link_/dev_portal_start/_clicked">
+    Getting Started
   </TrackingLink>
-</p>
-
-<span>https://rest-mainnet.onflow.org/v1/</span>
-<p>
-  Mainnet:{" "}
-  <TrackingLink
-    event="Homepage*link*/http-api-mainnet/\_clicked"
-    href="/http-api/"
-  >
-    View Documentation
-  </TrackingLink>
-</p>
-
-<p>
-  Oh, that's new. 
-</p>
-</li>
+  </li>
 </ul>
 
 </div>
@@ -368,6 +340,17 @@ import {
     SDK Guidelines
     </TrackingLink> <br/>
     <p>Considering building an SDK for Flow? These guidelines will help light your path.</p>
+  </li>
+   <li>
+    <TrackingLink
+      event="Homepage*link*/http-api-testnet/\_clicked"
+      href="/http-api/"
+    >
+      Access Node - HTTP API 
+    </TrackingLink> <br/>
+    <p>Flow Access Nodes now have an HTTP API.</p>
+    <p> <span>Mainnet: https://rest-mainnet.onflow.org/v1/</span> </p>
+    <p> <span>Testnet: https://rest-testnet.onflow.org/v1/</span></p>
   </li>
   <li>
     <TrackingLink href="/fcl/" eventName="Homepage_link_/fcl/_clicked">


### PR DESCRIPTION
- Removes HTTP API from `Getting Started` to the SDK section
- Adds links and description of the new developer portal as the hero content