### PR TITLE
add missing block_height to TransactionResult

### DIFF
--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -675,6 +675,7 @@ components:
     TransactionResult:
       type: object
       required:
+        - block_height
         - block_id
         - status
         - status_code
@@ -682,6 +683,8 @@ components:
         - computation_used
         - events
       properties:
+        block_height:
+          $ref: '#/components/schemas/BlockHeight'
         block_id:
           $ref: '#/components/schemas/Identifier'
         execution:


### PR DESCRIPTION
Closes: #1024 

## Description

block_height is missing from schema

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
