### PR TITLE
Add new line to docs index file for rendering

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -59,8 +59,10 @@ import {
 
 <ul className="grid-item-list">
   <li>
-    <TrackingLink  href="/fcl/tutorials/flow-app-quickstart/" eventName="Homepage_link_/fcl/tutorials/flow-app-quickstart/_clicked">Flow App Quickstart</TrackingLink> <br/>
-    <p>A detailed guide covering how to use the <TrackingLink href="/flow-js-sdk/" eventName="Homepage_link_/flow-js-sdk/_clicked">FCL (Flow Client Library)</TrackingLink> to build a serverless app that connects to Flow, using React!</p>
+    <TrackingLink href="/fcl/tutorials/flow-app-quickstart/" eventName="Homepage_link_/fcl/tutorials/flow-app-quickstart/_clicked">Flow App Quickstart</TrackingLink> <br/>
+    <p>
+      A detailed guide covering how to use the <TrackingLink href="/flow-js-sdk/" eventName="Homepage_link_/flow-js-sdk/_clicked">FCL (Flow Client Library)</TrackingLink> to build a serverless app that connects to Flow, using React!
+    </p>
     <p>Ready to jump right in? Use one of our quickstart projects:&nbsp;
       <TrackingLink href="https://github.com/muttoni/fcl-sveltekit-quickstart" eventName="Homepage_link_/https://github.com/muttoni/fcl-sveltekit-quickstart/_clicked">
       SvelteKit


### PR DESCRIPTION
No issue created

- added a new line for <p> tags as an attempt to render this file
- error in mdx rendering shown below

```
✘ [ERROR] [plugin @mdx-js/esbuild] Expected a closing tag for `<p>` (64:5-64:8) before the end of `paragraph`

    _mdx_bundler_entry_point-32b10e20-7413-47e0-9d34-d660d585b91f.mdx:62:4:
      62 │     <TrackingLink  href="/fcl/tutorials/flow-app-quickstart/" eventName="Homepage_link_/fcl/tutorials/flow-app-quickstart/_clicked">Flow App Quickstart</TrackingLink> <br/>
         ╵     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
