### PR TITLE
Convert bounties table to markdown

### DIFF
--- a/docs/content/bounties/index.mdx
+++ b/docs/content/bounties/index.mdx
@@ -19,77 +19,13 @@ If you believe you may have found a security vulnerability in one of our product
   are willing to pay $100,000 or more (To a maximum of $1M of rewards per person
   or organization within any 12 consecutive months) at our sole discretion.
 </p>
-<table>
-  <tbody style="font-size: 12px;">
-    <tr>
-      <th>Bug Type</th>
-      <th>Reward</th>
-      <th>Criteria</th>
-      <th>Example</th>
-    </tr>
-    <tr>
-      <td>Critical-Impact Vulnerability</td>
-      <td align="center">min. $100k</td>
-      <td align="left">
-        <ul>
-          <li style="font-size: 12px;">Emergency remediation</li>
-          <li style="font-size: 12px;">Public announcement</li>
-          <li style="font-size: 12px;">
-            Typically a remote, unauthenticated compromise of application
-          </li>
-          <li style="font-size: 12px;">Hard-forking of a smart contract</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li style="font-size: 12px;">Loss of funds</li>
-          <li style="font-size: 12px;">Consensus violations</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>High-Impact Vulnerability</td>
-      <td align="center">min. $50k</td>
-      <td align="left">
-        <ul>
-          <li style="font-size: 12px;">
-            Immediate analysis and action is necessary
-          </li>
-          <li style="font-size: 12px;">Public disclosure in most cases</li>
-          <li style="font-size: 12px;">
-            Exploitation would significantly affect the business
-          </li>
-          <li style="font-size: 12px;">Eventual fix of smart contract</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>Medium-Impact Vulnerability</td>
-      <td align="center">$25k</td>
-      <td align="left">
-        <ul>
-          <li style="font-size: 12px;">
-            Remediation required, but impact is not significant
-          </li>
-        </ul>
-      </td>
-      <td align="left"></td>
-    </tr>
-    <tr>
-      <td>Low-Impact Vulnerability</td>
-      <td align="center">$2.5k</td>
-      <td align="left">
-        <ul>
-          <li style="font-size: 12px;">
-            Low risk issues like misconfigurations with no proven path to
-            exploit
-          </li>
-        </ul>
-      </td>
-      <td align="left"></td>
-    </tr>
-  </tbody>
-</table>
+
+| Bug Type | Reward | Criteria | Example |
+| :--- | :---: | :--- | :--- |
+| Critical-Impact Vulnerability | min. $100k | <ul><li>Emergency remediation</li><li>Public announcement</li><li>Typically a remote, unauthenticated compromise of application</li><li>Hard-forking of a smart contract</li></ul> | <ul><li>Loss of funds</li><li>Consensus violations</li></ul> |
+| High-Impact Vulnerability | min. $50k | <ul><li>Immediate analysis and action is necessary</li><li>Public disclosure in most cases</li><li>Exploitation would significantly affect the business</li><li>Eventual fix of smart contract</li></ul> | |
+| Medium-Impact Vulnerability | $25k | <ul><li>Remediation required, but impact is not significant</li></ul> | |
+| Low-Impact Vulnerability | $2.5k | <ul><li>Low risk issues like misconfigurations with no proven path to exploit</li></ul> | |
 
 ## Eligibility
 


### PR DESCRIPTION
Closes: https://github.com/onflow/next-docs-v1/issues/352

## Description

[next-docs-v1 ](https://github.com/onflow/next-docs-v1) requires jsx instead of html. Convert table to markdown.

![image](https://user-images.githubusercontent.com/1160249/181820290-2873a4f4-2bc0-4c3f-95fd-1608197fd496.png)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
