### PR TITLE
Updated flow domain in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# [Flow](https://www.onflow.org)
+# [Flow](https://www.flow.com)
 
 Flow is a fast, secure, and developer-friendly blockchain built to support the next generation of games, apps, and the digital assets that power them.
 
-- For a high-level overview of Flow's architecture, check out the [primer](https://www.onflow.org/primer).
-- Details about the protocol can be found in the [technical papers](https://www.onflow.org/technical-paper).
-- For more documentation and tutorials, check out [docs.onflow.org](https://docs.onflow.org/docs).
+- For a high-level overview of Flow's architecture, check out the [primer](https://www.flow.com/primer).
+- Details about the protocol can be found in the [technical papers](https://www.flow.com/technical-paper).
+- For more documentation and tutorials, check out [developer portal](https://developers.flow.com).
 


### PR DESCRIPTION
Flow has moved from onflow.org to flow.com
Docs is now called developer portal @ https://developers.flow.com/