### PR TITLE
FLIP for `publish` and `claim` for capabilities

### DIFF
--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -113,13 +113,13 @@ the program will fail.
 This FLIP also adds two new events to Cadence:
 
 ```cadence
-event InboxValuePublished(provider: Address, name: String, type: Type) 
+event InboxValuePublished(provider: Address, recipient: Address, name: String, type: Type) 
 
 event InboxValueRemoved(provider: Address, remover: Address, name: String)
 ```
 
 These events are emitted whenever a value is added or removed from an inbox's publishing dictionary. When `publish` is called,
-`InboxValuePublished` is emitted containing the address of the `provider`, the `name` the value was published with, and the runtime
+`InboxValuePublished` is emitted containing the address of the `provider` and the `recipient`, the `name` the value was published with, and the runtime
 `type` it was published with. When a value is `claim`ed or `unpublish`ed, `InboxValueRemoved` is emitted, including the address the value was
 originally published from (`provider`), the address of the `remover` (in the case of `claim`, this is the recipient's address, in the case of 
 `unpublish` it is the same as the `provider`), and the `name` of the removed event. 

--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -5,7 +5,7 @@
 | **FLIP #**    | [NNN](https://github.com/onflow/flow/pull/NNN) (update when you have PR #)|
 | **Author(s)** | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
 | **Sponsor**   | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
-| **Updated**   | 2022-09-12                                           |
+| **Updated**   | 2022-09-13                                           |
 | **Obsoletes** | https://github.com/onflow/flow/pull/945              |
 
 ## Objective
@@ -38,10 +38,12 @@ to share specific values directly with another account.
 
 ## Design Proposal
 
-This adds two new functions to `AuthAccount`s:
+This adds three new functions to `AuthAccount`s:
 
 ```cadence
 fun publish(_ value: Any, name: String, recipient: Address)
+
+fun unpublish<T : Any>(_ name: String): T?
 
 fun claim<T: Any>(_ name: String, provider: Address): T?
 ```
@@ -96,6 +98,13 @@ transaction() {
   }
 }
 ```
+
+The `unpublish` function exists so that a provider can remove a published value from their storage, so that it
+stops taking up space if it goes un`claim`ed by its intended recipient. The calling account (the original provider
+of the value) calls `unpublish` with the same `name` that the value was originally stored with. If a value with that 
+`name` is present in the account's publishing dictionary, and the provided type argument to `unpublish` is a supertype
+of that value's runtime type, then the function will return that value and remove it from the dictionary. Otherwise, 
+the function returns `nil`. 
 
 ### Alternatives Considered
 

--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -1,0 +1,169 @@
+# Publish/Claim Capability
+
+| Status        | (Proposed / Rejected / Accepted / Implemented)       |
+:-------------- |:---------------------------------------------------- |
+| **FLIP #**    | [NNN](https://github.com/onflow/flow/pull/NNN) (update when you have PR #)|
+| **Author(s)** | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
+| **Sponsor**   | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
+| **Updated**   | 2022-09-09                                           |
+| **Obsoletes** | https://github.com/onflow/flow/pull/945              |
+
+## Objective
+
+What are we doing and why? What problem will this solve? What are the goals and
+non-goals? This is your executive summary; keep it short, elaborate below.
+
+## Motivation
+
+Why is this a valuable problem to solve? What background information is needed
+to show how this design addresses the problem?
+
+Which users are affected by the problem? Why is it a problem? What data supports
+this? What related work exists?
+
+## User Benefit
+
+How will users (or other contributors) benefit from this work? What would be the
+headline in the release notes or blog post?
+
+## Design Proposal
+
+This adds two new functions to `AuthAccount`s:
+
+```cadence
+fun publish(_ value: Any, name: String, recipient: Address)
+
+fun claim<T: Any>(_ name: String, provider: Address): T?
+```
+
+The `publish` function takes a `value` argument, a `name` string that identifies it, 
+and a `recipient` address that specifies which account should be allowed to `claim` the 
+published `value` later. When `publish` is called, `value` and its intended `recipient` are stored
+in a publishing dictionary on the calling account (not accessible to users), with the `name` as its key.
+
+The `claim` function takes the `name` of the value to be claimed and an `provider` address that
+specifies which account is providing the value, as well as a type argument `T` that specifies
+the type with which the value should be claimed. When called, `claim` will search the `provider`s 
+publishing dictionary for the `name` key. If the key does not exist on the map, `claim` returns `nil`. 
+
+If the key does exist, then `claim` compares the stored `recipient` (from the original call to `publish`) 
+to see if it matches the address of the account calling `claim`. If it does not, then `claim` returns `nil`. 
+If it does match, then the runtime type of the published `value` compared against the type argument `T`. If 
+it does not match, then `claim` returns `nil`. If it does, `value` is removed from the `provider`'s dictionary and 
+returned to the `claim` calling account. In effect, this means that a `publish`ed value can only be `claim`ed once. 
+
+An example of how this might look, when bootstrapping a capability to a resource owned by 0x1:
+
+```cadence
+// transaction 1 (from the original resource owner 0x1)
+import MyIntf from 0x1
+
+transaction() {
+  prepare(acct: AuthAccount) {
+    // create a capability to a resource stored at /storage/myResource.
+    // With the changes proposed in https://github.com/onflow/flow/pull/798, this may
+    // not involve linking to a concrete path, but at the moment the only way to create
+    // a capability is via `link` 
+    let cap = acct.link<&MyIntf>(/private/myCapability, target: /storage/myResource)
+    acct.publish(cap, name: "yourCapability", recipient: 0x2)
+  }
+}
+```
+
+```cadence
+// transaction 2 (from the reciever of the capability 0x2)
+import MyIntf from 0x1
+
+transaction() {
+  prepare(acct: AuthAccount) {
+    let cap = acct.claim<Capability<MyIntf>>("yourCapability", provider: 0x1)
+    // if we successfully obtain the capability, store it on our account
+    if cap != nil {
+        acct.save(cap, to: /storage/myCapability)
+    }
+  }
+}
+```
+
+### Drawbacks
+
+Why should this *not* be done? What negative impact does it have? 
+
+### Alternatives Considered
+
+* Make sure to discuss the relative merits of alternatives to your proposal.
+
+### Performance Implications
+
+* Do you expect any (speed / memory)? How will you confirm?
+* There should be microbenchmarks. Are there?
+* There should be end-to-end tests and benchmarks. If there are not 
+(since this is still a design), how will you track that these will be created?
+
+### Dependencies
+
+* Dependencies: does this proposal add any new dependencies to Flow?
+* Dependent projects: are there other areas of Flow or things that use Flow 
+(Access API, Wallets, SDKs, etc.) that this affects? 
+How have you identified these dependencies and are you sure they are complete? 
+If there are dependencies, how are you managing those changes?
+
+### Engineering Impact
+
+* Do you expect changes to binary size / build time / test times?
+* Who will maintain this code? Is this code in its own buildable unit? 
+Can this code be tested in its own? 
+Is visibility suitably restricted to only a small API surface for others to use?
+
+### Best Practices
+
+* Does this proposal change best practices for some aspect of using/developing Flow? 
+How will these changes be communicated/enforced?
+
+### Tutorials and Examples
+
+* If design changes existing API or creates new ones, the design owner should create 
+end-to-end examples (ideally, a tutorial) which reflects how new feature will be used. 
+Some things to consider related to the tutorial:
+    - It should show the usage of the new feature in an end to end example 
+    (i.e. from the browser to the execution node). 
+    Many new features have unexpected effects in parts far away from the place of 
+    change that can be found by running through an end-to-end example.
+    - This should be written as if it is documentation of the new feature, 
+    i.e., consumable by a user, not a Flow contributor. 
+    - The code does not need to work (since the feature is not implemented yet) 
+    but the expectation is that the code does work before the feature can be merged. 
+
+### Compatibility
+
+* Does the design conform to the backwards & forwards compatibility [requirements](../docs/compatibility.md)?
+* How will this proposal interact with other parts of the Flow Ecosystem?
+    - How will it work with FCL?
+    - How will it work with the Emulator?
+    - How will it work with existing Flow SDKs?
+
+### User Impact
+
+* What are the user-facing changes? How will this feature be rolled out?
+
+## Related Issues
+
+What related issues do you consider out of scope for this proposal, 
+but could be addressed independently in the future?
+
+## Prior Art
+
+Does the proposed idea/feature exist in other systems and 
+what experience has their community had?
+
+This section is intended to encourage you as an author to think about the 
+lessons learned from other projects and provide readers of the proposal 
+with a fuller picture.
+
+It's fine if there is no prior art; your ideas are interesting regardless of 
+whether or not they are based on existing work.
+
+## Questions and Discussion Topics
+
+Seed this with open questions you require feedback on from the FLIP process. 
+What parts of the design still need to be defined?

--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -43,7 +43,7 @@ defined as a nested composite on `AuthAccount`:
 
 ```cadence
 struct Inbox {
-    fun publish(_ value: Capability<Any>, name: String, recipient: Address)
+    fun publish(_ value: Capability, name: String, recipient: Address)
 
     fun unpublish<T : Any>(_ name: String): Capability<T>?
 

--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -1,6 +1,6 @@
 # Publish/Claim Capability
 
-| Status        | (Proposed / Rejected / Accepted / Implemented)       |
+| Status        | (Accepted)       |
 :-------------- |:---------------------------------------------------- |
 | **FLIP #**    | [1122](https://github.com/onflow/flow/pull/1122)     |
 | **Author(s)** | Daniel Sainati (daniel.sainati@dapperlabs.com)       |

--- a/flips/20220908-publish-claim-capability.md
+++ b/flips/20220908-publish-claim-capability.md
@@ -49,11 +49,11 @@ struct Inbox {
 
     fun unpermit(_ provider: Address)
 
-    fun publish(_ value: Capability<&Any>, name: String, recipient: Address): Bool
+    fun publish(_ value: Capability<Any>, name: String, recipient: Address): Bool
 
-    fun unpublish<T : &Any>(_ name: String): Capability<T>?
+    fun unpublish<T : Any>(_ name: String): Capability<T>?
 
-    fun claim<T: &Any>(_ name: String, provider: Address): Capability<T>?
+    fun claim<T: Any>(_ name: String, provider: Address): Capability<T>?
 }
 ```
 


### PR DESCRIPTION
Adds a new proposal for a pair of API functions: `publish` and `claim` that are designed to address the capability bootstrapping use case detailed here https://github.com/onflow/cadence/issues/1951

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
