### PR TITLE
Add Flow NFT Catalog To The Docs.

### DIFF
--- a/docs/content/core-contracts/nft-metadata.mdx
+++ b/docs/content/core-contracts/nft-metadata.mdx
@@ -14,3 +14,11 @@ Source: [MetadataViews.cdc](https://github.com/onflow/flow-nft/blob/master/contr
 | ------- | -------------------- |
 | Testnet | `0x631e88ae7f1d7c20` |
 | Mainnet | `0x1d7e57aa55817448` |
+
+There exists a tool, [Flow NFT Catalog](https://flow-nft-catalog.com), which enables dapp developers the ability to unlock interoperability of your NFT collection across the Flow ecosystem. This will help make your NFT collection’s metadata more discoverable and interoperable.
+
+To optimize your NFT collections for this catalog, you’ll need to:
+
+1. Update your NFT contract to support MetadataView with implementation of the [core NFT views](https://github.com/onflow/flow-nft/pull/103/files#diff-a7af41cf43e29d0e6028827c3d5f305326677661bf65d79539d59ed1056c0a84R38).
+2. Deploy the updated contract to both testnet and mainnet.
+3. Afterwards, onboard your NFT to the Flow NFT catalog at [https://flow-nft-catalog.com](https://flow-nft-catalog.com).


### PR DESCRIPTION
Closes: N/A

## Description

The NFT Catalog is live, and we want to expose this information to developers on the doc site.  This particular page seems like a good fit - https://developers.flow.com/flow/core-contracts/nft-metadata.

Feel free to propose different verbiage, or a different page altogether.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
