### PR TITLE
fix link to api docs

### DIFF
--- a/docs/content/faq/backers.mdx
+++ b/docs/content/faq/backers.mdx
@@ -29,4 +29,4 @@ Details: [https://docs.onflow.org/concepts/accounts-and-keys](https://docs.onflo
 
 ## How do I create a Flow account if I do not have a service account?
 
-Instructions to generate an address are here: [https://docs.onflow.org/flow-go-sdk/creating-accounts](https://docs.onflow.org/flow-go-sdk/creating-accounts). You don't need a service account.
+Instructions to generate an address are here: [https://docs.onflow.org/flow-go-sdk/creating-accounts](https://developers.flow.com/tools/flow-go-sdk#create-accounts). You don't need a service account.

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -25,7 +25,7 @@ Once you have connected to an access node, you can fetch information regarding a
 
 #### Accounts, Contracts, Blocks, Collections, Transactions, Events
 
-These types are documented on the [Access API](https://docs.onflow.org/http-api) page.
+These types are documented on the [Access API](https://developers.flow.com/http-api) page.
 
 The SDKs expose Flow data as types. For example the Go Flow Block data type implementation can be found here:
 

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -172,11 +172,11 @@ Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee
 
 ## How can I deploy a contract?
 
-To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](/dapp-development/deployment.md).
+To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](https://developers.flow.com/flow/dapp-development/deployment).
 
 ## How can I create my first account for mainnet?
 
-New accounts can be created using Flow Port. You can [follow these guidelines to get a new mainnet account](/flow-port/#creating-an-account).
+New accounts can be created using Flow Port. You can [follow these guidelines to get a new mainnet account](https://developers.flow.com/nodes/flow-port/index#creating-an-account).
 
 ## How can I deploy a contract to mainnet?
 
@@ -184,15 +184,15 @@ Please review the [Dapp Deployment guide](https://docs.onflow.org/dapp-deploymen
 
 ## Is there a testnet/devnet?
 
-There is an access node for you to develop against on the testnet/devnet. You can learn more about it here [https://docs.onflow.org/dapp-development/testnet-deployment#accessing-flow-testnet](/dapp-development/testnet-deployment#accessing-flow-testnet)
+There is an access node for you to develop against on the testnet/devnet. You can learn more about it here [https://developers.flow.com/flow/dapp-development/testnet-deployment#accessing-flow-testnet](https://developers.flow.com/flow/dapp-development/testnet-deployment#accessing-flow-testnet)
 
 ## Is there a public node?
 
-Yes, an access node is publicly accessible to submit transactions and read data from the blockchain. If you’d like to access the devnet access node to build against, you can do so [here](/concepts/accessing-testnet)
+Yes, an access node is publicly accessible to submit transactions and read data from the blockchain. If you’d like to access the devnet access node to build against, you can do so [here](https://developers.flow.com/learn/concepts/accessing-testnet#accessing-flow-testnet)
 
 ## Is it possible to add multiple public keys to a given account/address so that it can be controlled by more than one private key?
 
-Yes, accounts support multiple, weighted keys, [here](/cadence/language/accounts)
+Yes, accounts support multiple, weighted keys, [here](https://developers.flow.com/cadence/language/accounts)
 using `AuthAccount`’s `fun addPublicKey(_ publicKey: [UInt8])`and <br/>`fun removePublicKey(_ index: Int)` functions.
 
 ## How do keys and accounts work on Flow?
@@ -201,7 +201,7 @@ Accounts are created with associated keys. There can be multiple keys on an acco
 
 FLOW supports a variety of signature schemes for adding keys to an account.
 
-Details: [https://docs.onflow.org/concepts/accounts-and-keys](/concepts/accounts-and-keys)
+Details: [https://developers.flow.com/learn/concepts/accounts-and-keys](https://developers.flow.com/learn/concepts/accounts-and-keys)
 
 ## How can I see what Fungible-Tokens an account has?
 
@@ -217,15 +217,15 @@ Flow doesn't yet provide functionality to inspect all of the resources on an acc
 
 ## How do I create a Flow account if I do not have a service account?
 
-Instructions to generate an address are here: [https://docs.onflow.org/flow-go-sdk/creating-accounts](/flow-go-sdk/creating-accounts). You don't need a service account.
+Instructions to generate an address are here: [https://developers.flow.com/tools/flow-go-sdk#create-accounts](https://developers.flow.com/tools/flow-go-sdk#create-accounts). You don't need a service account.
 
 ## Is there a tutorial about how to access flow testnet? From scratch, getting testnet, Flow token etc..?
 
-Yes: [https://docs.onflow.org/dapp-development/testnet-deployment/](/dapp-development/testnet-deployment/)
+Yes: [https://docs.onflow.org/dapp-development/testnet-deployment](https://developers.flow.com/flow/dapp-development/testnet-deployment)
 
 ## Can you query events between a block range?
 
-You can query the access API to get events for a block range. See Access API spec here: [https://docs.onflow.org/access-api](/access-api).
+You can query the access API to get events for a block range. See Access API spec here: [https://developers.flow.com/http-api](https://developers.flow.com/http-api).
 
 ## Where can I follow feature releases on Flow?
 

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -83,7 +83,7 @@ You can find examples of querying an access node at the bottom of this page:
 
 You can find examples using the emulator that can be adapted to use an access node here:
 
-[https://github.com/onflow/flow-go-sdk/blob/master/examples/query_events/main.go](https://github.com/onflow/flow-go-sdk/blob/master/examples/query_events/main.go)
+[https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events/main.go](https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events/main.go)
 
 And here is an example of using a script:
 
@@ -125,8 +125,8 @@ This is documented here:
 [https://github.com/onflow/flow-go-sdk#querying-events](https://github.com/onflow/flow-go-sdk#querying-events)
 
 And there is an example of usage here:
-
-[https://github.com/onflow/flow-go-sdk/tree/master/examples/query_events](https://github.com/onflow/flow-go-sdk/tree/master/examples/query_events)
+https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events/main.go
+[https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events](https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events)
 
 ### Using JavaScript
 
@@ -156,9 +156,9 @@ With FCL, you can:
 
 ## How do I access mainnet?
 
-You can find details about accessing Flow mainnet here [https://docs.onflow.org/access-api](https://docs.onflow.org/access-api).
+You can find details about accessing Flow mainnet here [https://developers.flow.com/http-api](https://developers.flow.com/http-api).
 
-The access is via a GRPC interface. Transactions can also be submitted using the GRPC [SendTransaction call](https://docs.onflow.org/access-api#sendtransaction). A GRPC client written in any language should be able to talk via the Access API. We have a [Go SDK](https://github.com/onflow/flow-go-sdk) and [FCL-JS (Flow Client Library)](https://github.com/onflow/fcl-js) that can be used if you are using a Go based or a JS based client respectively.
+The access is via a GRPC interface. Transactions can also be submitted using the GRPC [SendTransaction call](https://developers.flow.com/http-api#tag/Transactions/paths/~1transactions/post). A GRPC client written in any language should be able to talk via the Access API. We have a [Go SDK](https://github.com/onflow/flow-go-sdk) and [FCL-JS (Flow Client Library)](https://github.com/onflow/fcl-js) that can be used if you are using a Go based or a JS based client respectively.
 
 ## What's the difference between a mainnet spork and testnet spork? How do sporks affect TopShot?
 

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -172,6 +172,8 @@ Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee
 
 ## How can I deploy a contract?
 
+
+
 To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](https://developers.flow.com/flow/dapp-development/deployment).
 
 ## How can I create my first account for mainnet?

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -25,7 +25,7 @@ Once you have connected to an access node, you can fetch information regarding a
 
 #### Accounts, Contracts, Blocks, Collections, Transactions, Events
 
-These types are documented on the [Access API](https://docs.onflow.org/access-api) page.
+These types are documented on the [Access API](https://docs.onflow.org/http-api) page.
 
 The SDKs expose Flow data as types. For example the Go Flow Block data type implementation can be found here:
 

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -172,7 +172,7 @@ Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee
 
 ## How can I deploy a contract?
 
-To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](/dapp-development/deployment/).
+To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](/dapp-development/deployment).
 
 ## How can I create my first account for mainnet?
 

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -172,8 +172,6 @@ Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee
 
 ## How can I deploy a contract?
 
-
-
 To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](https://developers.flow.com/flow/dapp-development/deployment).
 
 ## How can I create my first account for mainnet?

--- a/docs/content/faq/developers.mdx
+++ b/docs/content/faq/developers.mdx
@@ -172,7 +172,7 @@ Starting on October 16, 2021 at 7:30am PT (2:30pm UTC), there will be a flat fee
 
 ## How can I deploy a contract?
 
-To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](/dapp-development/deployment).
+To deploy a contract, please follow the steps outlined in the [Dapp Deployment guide](/dapp-development/deployment.md).
 
 ## How can I create my first account for mainnet?
 

--- a/docs/content/faq/operators.mdx
+++ b/docs/content/faq/operators.mdx
@@ -29,7 +29,7 @@ Once you have connected to an access node, you can fetch information regarding a
 
 #### Accounts, Contracts, Blocks, Collections, Transactions, Events
 
-These types are documented on the [Access API](https://docs.onflow.org/access-api) page.
+These types are documented on the [Access API](https://developers.flow.com/http-api) page.
 
 The SDKs expose Flow data as types. For example the Go Flow Block data type implementation can be found here:
 
@@ -69,7 +69,7 @@ Here are examples of creating a script and Cadence data types:
 
 And here are examples of parsing script output:
 
-[https://github.com/onflow/fcl-js/tree/master/packages/decode](https://github.com/onflow/fcl-js/tree/master/packages/decode)
+[https://github.com/onflow/fcl-js/tree/master/packages/decode](https://github.com/onflow/fcl-js/tree/master/packages/sdk/src/decode)
 
 #### Go
 
@@ -87,7 +87,7 @@ You can find examples of querying an access node at the bottom of this page:
 
 You can find examples using the emulator that can be adapted to use an access node here:
 
-[https://github.com/onflow/flow-go-sdk/blob/master/examples/query_events/main.go](https://github.com/onflow/flow-go-sdk/blob/master/examples/query_events/main.go)
+[https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events/main.go](https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events/main.go)
 
 And here is an example of using a script:
 
@@ -130,7 +130,7 @@ This is documented here:
 
 And there is an example of usage here:
 
-[https://github.com/onflow/flow-go-sdk/tree/master/examples/query_events](https://github.com/onflow/flow-go-sdk/tree/master/examples/query_events)
+[https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events)](https://github.com/onflow/flow-go-sdk/blob/master/examples/get_events)
 
 ### Using JavaScript
 
@@ -141,7 +141,7 @@ This is documented here:
 [https://github.com/onflow/fcl-js/tree/master/packages/sdk#getevents-usage](https://github.com/onflow/fcl-js/tree/master/packages/sdk#getevents-usage)
 And there is an example of usage here:
 
-[https://github.com/onflow/kitty-items/tree/master/kitty-items-js/src/workers](https://github.com/onflow/kitty-items/tree/master/kitty-items-js/src/workers)
+[https://github.com/onflow/kitty-items/tree/master/api/src/workers](https://github.com/onflow/kitty-items/tree/master/api/src/workers)
 
 ### Using Other Programming Languages
 
@@ -184,11 +184,11 @@ Details: [https://docs.onflow.org/concepts/accounts-and-keys](https://docs.onflo
 
 ## How do I create a Flow account if I do not have a service account?
 
-Instructions to generate an address are here: [https://docs.onflow.org/flow-go-sdk/creating-accounts](https://docs.onflow.org/flow-go-sdk/creating-accounts). You don't need a service account.
+Instructions to generate an address are here: [https://developers.flow.com/tools/flow-go-sdk#create-accounts](https://developers.flow.com/tools/flow-go-sdk#create-accounts). You don't need a service account.
 
 ## Can you query events between a block range?
 
-You can query the access API to get events for a block range. See Access API spec here: [https://docs.onflow.org/access-api](https://docs.onflow.org/access-api).
+You can query the access API to get events for a block range. See Access API spec here: [https://developers.flow.com/http-api](https://developers.flow.com/http-api).
 
 ## Where can I follow feature releases on Flow?
 


### PR DESCRIPTION
it seems that "access-api" has changed to "http-api", fixing link

closes https://github.com/onflow/developer-portal/issues/734

## Description

Link to api docs was broken, update link.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
