### PR TITLE
Update content docs for nft marketplace

### DIFF
--- a/docs/content/nft-marketplace/best-practices.md
+++ b/docs/content/nft-marketplace/best-practices.md
@@ -12,7 +12,7 @@ NFT purchase ultimately settles on the blockchain, but NFT buyers see the prices
 
 ## Clean up stale NFT listings
 
-Often, sellers change their listing price for the NFT on sale. That can lead to multiple listings on the chain. After a price change, marketplace platforms should ensure that any lower price listings are deleted from the chain. Also, once the NFT is sold, the marketplace should clean up all sale listings for that NFT.
+Often, sellers change their listing price for the NFT on sale. That can lead to multiple listings on the chain. After a price change, marketplace platforms should ensure that any lower price listings are deleted from the chain. Also, once the NFT is sold, the marketplace should [clean up](https://github.com/onflow/nft-storefront/blob/main/transactions/cleanup_purchased_listings.cdc) all sale listings for that NFT.
 
 ## Provide rich filtering/search capabilities
 

--- a/docs/content/nft-marketplace/building-blocks.md
+++ b/docs/content/nft-marketplace/building-blocks.md
@@ -31,5 +31,5 @@ If you are coming from Ethereum, the following list shows corresponding modules 
 | Wallet Interaction Library          | web3.js                 | [Flow Client Library (FCL)](https://github.com/onflow/fcl-js)                                                                     |
 | Blockchain Interaction SDK          | web3.js                 | [Flow Client Library (FCL)](https://github.com/onflow/fcl-js), [Flow Go SDK](https://github.com/onflow/flow-go-sdk), and [many others](https://github.com/onflow/flip-fest/blob/main/winners.md) |
 | Block Explorer                      | Etherscan               | Flowscan                                                                                              |
-| Node Service Providers              | Infura                  | [Official Flow Access Nodes](https://flowscan.org/staking/nodes), [Alchemy](https://www.alchemy.com/)                        |
+| Node Service Providers              | Infura                  | [Official Flow Access Nodes](https://flowscan.org/staking/nodes)                        |
 | Wallets                             | Metamask, WalletConnect | [Blocto](https://portto.com/), [Dapper Wallet](https://www.meetdapper.com/)                           |

--- a/docs/content/nft-marketplace/handling-accounts.md
+++ b/docs/content/nft-marketplace/handling-accounts.md
@@ -19,16 +19,10 @@ Using FCL, you can get the authenticated account information for your users.
 
 ## Displaying NFTs belonging to the User
 
-[Alchemy NFT API ](https://docs.alchemy.com/flow/documentation/flow-nft-apis)is the best way to get the list of all NFTs owned by a user.
+NFT marketplaces can use the [Flow NFT Catalog](https://github.com/dapperlabs/nft-catalog), an on-chain registry of NFTs, to obtain the list of NFTs owned by an account and obtain display metadata for those NFTs and their collections. Developers should use the [example scripts](https://github.com/dapperlabs/nft-catalog#using-the-catalog-for-marketplaces-and-other-nft-applications) in conjunction with the [NFT Metadata Standard](https://github.com/onflow/flow-nft/#nft-metadata).
 
-To be precise, Alchemy API returns information about only the NFT projects integrated with Alchemy. Also, Alchemy API needs the Flow address as an input.
-
-The Sign-in/up step should provide the information about the user’s Flow address to the application.
-
-For an NFT project not integrated with the Alchemy API, to find out the NFTs owned by an account, you need to know the public path of that NFT’s collection. See [this](https://github.com/onflow/flow-nft#list-nfts-in-an-account) for more information.
+For an NFT project that is not yet present in the [Flow NFT Catalog](https://github.com/dapperlabs/nft-catalog), to find out the NFTs owned by an account, you need to know the public path of that NFT’s collection. See [this](https://github.com/onflow/flow-nft#list-nfts-in-an-account) for more information.
 
 ### Rendering NFTs
 
-Alchemy NFT API also provides rendering information for the NFTs. Check the [getNFTMetadata API](https://docs.alchemy.com/flow/documentation/flow-nft-apis/getnftmetadata-api).
-
-All newer NFT projects will conform to the [NFT Metadata Standard](https://github.com/onflow/flow-nft/#nft-metadata). You can use the Display view to get the rendering information from the NFTs conforming to the metadata standard. [Here](https://github.com/onflow/flow-nft#nft-metadata) is the code example on how to do that.
+All newer NFT projects will conform to the [NFT Metadata Standard](https://github.com/onflow/flow-nft/#nft-metadata). You can use the Display view to get the rendering information from the NFTs conforming to the metadata standard. [Here](https://github.com/onflow/flow-nft#how-to-read-metadata) is the code example on how to do that.

--- a/docs/content/nft-marketplace/minting-nfts.md
+++ b/docs/content/nft-marketplace/minting-nfts.md
@@ -10,8 +10,8 @@ An NFT marketplace can add support for minting NFTs on the Flow blockchain using
 
 A few important points to note:
 
-- Do implement your NFT contract to conform to the [NFT Metadata Standard](https://github.com/onflow/flow-nft/#nft-metadata). You should implement the “Display” view to provide the rendering information for the NFTs. This [code snippet](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc#L60) shows how to implement metadata in the NFT contract. Conforming to the metadata standard will facilitate rendering by wallets, tools, and other applications.
-- Do make sure to integrate with the [Alchemy API](https://gist.github.com/srinjoyc/0b7bb2153cea902de20d400cd56e3187). Doing so will ensure that wallets and other applications will render your NFTs. It will also guarantee the authenticity of NFTs minted by your application on other platforms.
+- Do implement your NFT contract to conform to the [NFT Metadata Standard](https://github.com/onflow/flow-nft/#nft-metadata). You should implement the “Display” view to provide the rendering information for the NFTs. This [code snippet](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc#L73) shows how to implement metadata in the NFT contract. Conforming to the metadata standard will facilitate rendering by wallets, tools, and other applications.
+- Do make sure to register your contract in the [Flow NFT Catalog](https://github.com/dapperlabs/nft-catalog). Doing so will ensure that wallets and other applications will render your NFTs. It will also guarantee the authenticity of NFTs minted by your application on other platforms.
 - Individual collections per user are not currently supported. So NFTs for all the users will have to share the same contract. You can include a field in the contract indicating a collection name specific to a creator.
 
 ## ​​Lazy Minting

--- a/docs/content/nft-marketplace/selling-nfts.md
+++ b/docs/content/nft-marketplace/selling-nfts.md
@@ -32,15 +32,15 @@ The sale listing specifies the fungible token the NFT is sold in. Typical fungib
 
 Flow blockchain has a feature that unless an account is setup to receive a particular NFT type, they can not receive NFTs of that type. That is why users need to authorize a transaction through their account to receive a specific NFT type. See [this](https://github.com/StarlyIO/flowfest-contracts/blob/master/transactions/setup_account.cdc#L218) for an example of a transaction code doing that.
 
-An NFT marketplace should enable users to set up their accounts to receive an NFT before purchasing that NFT. [Alchemy NFT API](https://github.com/alchemyplatform/alchemy-flow-contracts#running-the-code) can provide the storage path information to let platforms craft such account set up transactions.
+An NFT marketplace should enable users to set up their accounts to receive an NFT before purchasing that NFT. [Flow NFT Catalog](https://github.com/dapperlabs/nft-catalog) can provide the storage path information to let platforms craft such account set up transactions.
 
-After the NFT purchase operation is complete on the blockchain, The NFT marketplace platform should explicitly remove the sale listings. Leaving dangling sale listings is not a good practice.
+After the NFT purchase operation is complete on the blockchain, the NFT marketplace platform should explicitly [remove](https://github.com/onflow/nft-storefront/blob/main/transactions/cleanup_purchased_listings.cdc) the sale listings. Leaving dangling sale listings is not a good practice.
 
 ## Payment options
 
 Currently, for the on-chain sale of NFTs, the most common option is to let sellers list NFTs for sale in fungible tokens like FUSD or FLOW.
 
-The marketplace will have the NFT owner sign a transaction like [this](https://github.com/onflow/nft-storefront/blob/main/transactions/sell_item.cdc) to create the sale listing. The transaction [specifies](https://github.com/onflow/nft-storefront/blob/main/transactions/sell_item.cdc#L16) the type of fungible token the NFT seller will accept.
+The marketplace will have the NFT owner sign a transaction like [this](https://github.com/onflow/nft-storefront/blob/main/transactions/sell_item.cdc) to create the sale listing. The transaction [specifies](https://github.com/onflow/nft-storefront/blob/main/transactions/sell_item.cdc#L35) the type of fungible token the NFT seller will accept.
 
 If accepting any fungible token other than FLOW like FUSD, the seller needs to set up their account to accept that token. Here is a [setup transaction](https://github.com/onflow/fusd/blob/main/transactions/setup_fusd_vault.cdc) for FUSD that the marketplace needs the seller to sign.
 


### PR DESCRIPTION
Closes: [onflow/flow#1178](https://github.com/onflow/flow/issues/1178)

## Description

The `Alchemy NFT API` is no longer supporting Flow (as per this [changelog](https://docs.alchemy.com/changelog/110822-removed-support-for-flow-network)). All such references are updated with the `Flow NFT Catalog`. Also updated some links with code lines and linked some sample transactions.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
