### PR TITLE
Add NuFi to FUSD compatible wallets

### DIFF
--- a/docs/content/fusd/index.md
+++ b/docs/content/fusd/index.md
@@ -58,6 +58,7 @@ All FCL compatible wallets can be easily configured to also receive FUSD.
 
 FCL compatible wallets currently supporting FUSD include:
 - [Blocto](https://blocto.portto.io/)
+- [NuFi](https://nu.fi/)
 
 You can configure your Blocto wallet to hold FUSD in one of two ways:
 - **On mobile:** In the Blocto mobile app, add "Flow USD" as a token asset in the "Wallet" tab.


### PR DESCRIPTION
## Description

NuFi supports FUSD as a wallet. This PR adds this information to the Flow docs.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
