### PR TITLE
Archive node v1 access API docs

### DIFF
--- a/docs/content/node-operation/guides/starting-nodes.mdx
+++ b/docs/content/node-operation/guides/starting-nodes.mdx
@@ -6,16 +6,16 @@ Prior to starting up your nodes make sure you have the following items completed
 
 1. Bootstrap process completed with the bootstrap directory handy (default: `/var/flow/bootstrap`)
 2. Flow `data` directory created (default: `/var/flow/data`)
-3. [node config](https://docs.onflow.org/docs/genesis-bootstrapping#update-node-config) ready
+3. [node config](https://developers.flow.com/nodes/node-operation/node-bootstrap) ready
 4. Firewall exposes TCP/3569, and if you are running `access` node also the GRPC port (default: TCP/9000)
 
-For more details head back to [Setting up your node](https://docs.onflow.org/docs/setting-up-a-node#set-your-node-to-start)
+For more details head back to [Setting up your node](https://developers.flow.com/nodes/node-operation/node-setup#prepare-your-node-to-start)
 
 When you have all the above completed, you can start your Flow node via `systemd` or `docker`.
 
 ## systemd
 
-Ensure that you downloaded the systemd unit file. If you haven't, follow the [Set your node to start](https://docs.onflow.org/docs/setting-up-a-node#set-your-node-to-start) guide to get your unit file and enabled.
+Ensure that you downloaded the systemd unit file. If you haven't, follow the [Set your node to start](https://developers.flow.com/nodes/node-operation/node-setup#prepare-your-node-to-start) guide to get your unit file and enabled.
 
 Once you have your Flow service enabled you can now start your service: `systemctl start flow`
 

--- a/docs/content/node-operation/guides/starting-nodes.mdx
+++ b/docs/content/node-operation/guides/starting-nodes.mdx
@@ -111,3 +111,26 @@ docker run --rm \
 	--bind 0.0.0.0:3569 \
 	--loglevel=error
 ```
+
+### Archive
+
+```shell
+ docker run --rm \
+	-v /path/to/data:/data:rw \
+	--network host \
+	--label=project=flow \
+	--label=network=mainnet
+	--label=app=dps
+	--label=version=v0.26
+	--name flow-dps gcr.io/flow-container-registry/flow-dps-live:v0.26.1
+	--address 0.0.0.0:5005
+	--index /data/index
+	--bootstrap /data/bootstrap
+	--checkpoint /data/bootstrap/root.checkpoint
+	--data /data/protocol
+	--level debug
+	--metrics 0.0.0.0:8080
+	--bucket bucket_name
+	--seed-address=access_node_address
+	--seed-key=seed_key
+```

--- a/docs/content/node-operation/node-roles.mdx
+++ b/docs/content/node-operation/node-roles.mdx
@@ -9,7 +9,7 @@ Collection, consensus, execution, verification and access nodes are all staked n
 
 An observer node provides locally accessible, continuously updated, verified copy of the block data. It serves the Access API but unlike an access node, an observer node does not need to be staked, and **anyone** can run it without being added to the approved list of nodes.
 
-[Get started running an observer node](/nodes/node-operation/observer-node)
+[Get started running an observer node](https://developers.flow.com/nodes/node-operation/observer-node)
 
 ## Collection
 

--- a/docs/content/node-operation/node-roles.mdx
+++ b/docs/content/node-operation/node-roles.mdx
@@ -52,3 +52,11 @@ Verification nodes are required to stake a minimum of 135,000 FLOW to be a confi
 Access nodes act as a proxy to the Flow network. The Access node routes transactions to the correct Collection node and routes state queries to available nodes (while likely caching state to answer queries in a timely manner in the future). Dapps and user agents can submit their transactions to any Access node or run their own if they can't find a service provider they're happy with.
 
 Access nodes are required to stake a 0 FLOW to be a confirmed node operator.
+
+## Archive
+
+The Archive node provides a scalable and efficient way to access the history of Flow protocol and the execution state for the current spork.
+
+This node can be run by anyone without being staked or added to the approved list of nodes. The Archive node follows the chain, stores and indexes both protocol and execution state, and allows retrieval of blocks, collections, transactions and events from the genesis of the current spork.
+
+It also allows script execution and other read-only queries that require the execution state to be read.

--- a/docs/content/node-operation/node-setup.mdx
+++ b/docs/content/node-operation/node-setup.mdx
@@ -7,7 +7,7 @@ First you'll need to provision a machine or virtual machine to run your node sof
 
 ## Hardware Requirements
 
-The hardware your Node will need varies depending on the role your Node will play in the Flow network. For an overview of the differences see the [Node Roles Overview](/nodes/node-operation/node-roles).
+The hardware your Node will need varies depending on the role your Node will play in the Flow network. For an overview of the differences see the [Node Roles Overview](https://developers.flow.com/nodes/node-operation/node-roles).
 
 | Node Type | CPU | Memory | Disk | Example GCP Instance |
 |:----------------:| ---------:| ------:| ------:|:--------------:|
@@ -21,7 +21,7 @@ The hardware your Node will need varies depending on the role your Node will pla
 
 _Note: The above numbers represent our current best estimate for the state of the network. These will be actively updated as we continue benchmarking the network's performance._
 
-> To run an Observer node, follow this [guide](/nodes/node-operation/observer-node).
+> To run an Observer node, follow this [guide](https://developers.flow.com/nodes/node-operation/observer-node).
 
 ## Networking Requirements
 
@@ -104,7 +104,7 @@ As a rough benchmark for planning storage capacity, each Flow block will grow th
 ### Confidential Data & Files
 
 Flow stores dynamically generated confidential data in a separate database. We strongly recommend enabling encryption
-for this database - see [this guide](/nodes/node-operation/db-encryption-existing-operator/) for instructions.
+for this database - see [this guide](https://developers.flow.com/nodes/node-operation/db-encryption-existing-operator) for instructions.
 
 Confidential information used by Flow is stored in the `private-root-information` subtree of the `bootstrap` folder.
 In particular:

--- a/docs/content/node-operation/node-setup.mdx
+++ b/docs/content/node-operation/node-setup.mdx
@@ -274,6 +274,29 @@ docker run --rm \
 	--loglevel=error
 ```
 
+### Archive
+
+```shell
+ docker run --rm \
+	-v /path/to/data:/data:rw \
+	--network host \
+	--label=project=flow \
+	--label=network=mainnet
+	--label=app=dps
+	--label=version=v0.26
+	--name flow-dps gcr.io/flow-container-registry/flow-dps-live:v0.26.1
+	--address 0.0.0.0:5005
+	--index /data/index
+	--bootstrap /data/bootstrap
+	--checkpoint /data/bootstrap/root.checkpoint
+	--data /data/protocol
+	--level debug
+	--metrics 0.0.0.0:8080
+	--bucket bucket_name
+	--seed-address=access_node_address
+	--seed-key=seed_key
+```
+
 ## Start the Node
 
 Now that your node is provisioned and configured, it can be started.

--- a/docs/content/node-operation/node-setup.mdx
+++ b/docs/content/node-operation/node-setup.mdx
@@ -303,13 +303,13 @@ Now that your node is provisioned and configured, it can be started.
 
 <Callout type="warning">
 
-Before starting your node, ensure it is [registered](/nodes/node-operation/node-bootstrap/#step-2---stake-your-node) and [authorized](https://flow-docs-8kbrufdlq-onflow.vercel.app/nodes/node-operation/node-bootstrap/#confirming-authorization).
+Before starting your node, ensure it is [registered](https://developers.flow.com/nodes/node-operation/node-bootstrap/#step-2---stake-your-node) and [authorized](https://developers.flow.com/nodes/node-operation/node-bootstrap#confirming-authorization).
 
 </Callout>
 
 Ensure you start your node at the appropriate time.
-See [Spork Process](/nodes/node-operation/spork) for when to start up a node following a spork.
-See [Node Bootstrap](/nodes/node-operation/node-bootstrap#timing) for when to start up a newly registered node.
+See [Spork Process](https://developers.flow.com/nodes/node-operation/spork) for when to start up a node following a spork.
+See [Node Bootstrap](https://developers.flow.com/nodes/node-operation/node-bootstrap#timing) for when to start up a newly registered node.
 
 ### Systemd
 
@@ -352,7 +352,7 @@ CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
 
 ## Monitoring and Metrics
 
-This is intended for operators who would like to see what their Flow nodes are currently doing. Head over to [Monitoring Node Health](/nodes/node-operation/monitoring-nodes/) to get setup.
+This is intended for operators who would like to see what their Flow nodes are currently doing. Head over to [Monitoring Node Health](https://developers.flow.com/nodes/node-operation/monitoring-nodes/) to get setup.
 
 ### Node Status
 

--- a/docs/content/node-operation/node-setup.mdx
+++ b/docs/content/node-operation/node-setup.mdx
@@ -17,6 +17,7 @@ The hardware your Node will need varies depending on the role your Node will pla
 | **Verification** |  2 cores  | 16 GB  | 200 GB | n2-highmem-2   |
 | **Access**       |  16 cores | 64 GB  | 900 GB | n2-standard-16 |
 | **Observer**     |  2 cores  | 4 GB   | 300 GB | n2-standard-4  |
+| **Archive**      | 32 cores  | 800 GB |  2 TB  | m3-ultramem-32 |
 
 _Note: The above numbers represent our current best estimate for the state of the network. These will be actively updated as we continue benchmarking the network's performance._
 

--- a/docs/content/nodes/access-api.mdx
+++ b/docs/content/nodes/access-api.mdx
@@ -31,7 +31,7 @@ The Access Nodes hosted by DapperLabs are accessible at:
 
 #### Rate limits for Dapper Labs access nodes
 
-Access nodes operated by Dapper Labs are [rate limited](/nodes/access-api-rate-limits).
+Access nodes operated by Dapper Labs are [rate limited](https://developers.flow.com/nodes/access-api-rate-limits).
 
 ---
 
@@ -503,7 +503,7 @@ message AccountResponse {
 }
 ```
 
-## 
+##
 
 ## Scripts
 
@@ -511,7 +511,7 @@ message AccountResponse {
 
 `ExecuteScriptAtLatestBlock` executes a read-only Cadence script against the latest sealed execution state.
 
-This method can be used to read execution state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+This method can be used to read execution state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](https://developers.flow.com/cadence/json-cadence-spec).
 
 ```protobuf
 rpc ExecuteScriptAtLatestBlock (ExecuteScriptAtLatestBlockRequest) returns (ExecuteScriptResponse)
@@ -550,7 +550,7 @@ message ExecuteScriptResponse {
 
 `ExecuteScriptAtBlockID` executes a ready-only Cadence script against the execution state at the block with the given ID.
 
-This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](https://developers.flow.com/cadence/json-cadence-spec).
 
 ```protobuf
 rpc ExecuteScriptAtBlockID (ExecuteScriptAtBlockIDRequest) returns (ExecuteScriptResponse)
@@ -583,7 +583,7 @@ message ExecuteScriptResponse {
 
 `ExecuteScriptAtBlockHeight` executes a ready-only Cadence script against the execution state at the given block height.
 
-This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](https://developers.flow.com/cadence/json-cadence-spec).
 
 ```protobuf
 rpc ExecuteScriptAtBlockHeight (ExecuteScriptAtBlockHeightRequest) returns (ExecuteScriptResponse)
@@ -787,7 +787,7 @@ The following method can be used to query the for [execution results](https://gi
 ### GetExecutionResultForBlockID
 
 `GetExecutionResultForBlockID` retrieves execution result for given block. It is different from Transaction Results,
-and contain data about chunks/collection level execution results rather than particular transactions. 
+and contain data about chunks/collection level execution results rather than particular transactions.
 Particularly, it contains `EventsCollection` hash for every chunk which can be used to verify the events for a block.
 
 ```protobuf
@@ -949,7 +949,7 @@ message TransactionSignature {
 | Field                         | Description                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
 | script                        | Raw source code for a Cadence script, encoded as UTF-8 bytes                                         |
-| arguments                     | Arguments passed to the Cadence script, encoded as [JSON-Cadence](/cadence/json-cadence-spec) bytes |
+| arguments                     | Arguments passed to the Cadence script, encoded as [JSON-Cadence](https://developers.flow.com/cadence/json-cadence-spec) bytes |
 | reference_block_id            | Block ID used to determine transaction expiry                                                        |
 | [proposal_key](#proposal-key) | Account key used to propose the transaction                                                          |
 | payer                         | Address of the payer account                                                                         |
@@ -1072,7 +1072,7 @@ message Event {
 | transaction_id    | ID of the transaction the event was emitted from                           |
 | transaction_index | Zero-based index of the transaction within the block                       |
 | event_index       | Zero-based index of the event within the transaction                       |
-| payload           | Event fields encoded as [JSON-Cadence values](/cadence/json-cadence-spec) |
+| payload           | Event fields encoded as [JSON-Cadence values](https://developers.flow.com/cadence/json-cadence-spec) |
 
 ## Execution Result
 

--- a/docs/content/nodes/archive-access-api.mdx
+++ b/docs/content/nodes/archive-access-api.mdx
@@ -30,7 +30,7 @@ The Archive Nodes hosted by DapperLabs are accessible at:
 
 #### Rate limits for Dapper Labs archive nodes
 
-Archive nodes operated by Dapper Labs are [rate limited](/nodes/archive-api-rate-limits).
+Archive nodes operated by Dapper Labs are [rate limited](https://developers.flow.com/nodes/archive-api-rate-limits).
 
 ---
 
@@ -74,7 +74,7 @@ message AccountResponse {
 
 `ExecuteScriptAtBlockID` executes a ready-only Cadence script against the execution state at the block with the given ID.
 
-This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](https://developers.flow.com/cadence/json-cadence-spec).
 
 ```protobuf
 rpc ExecuteScriptAtBlockID (ExecuteScriptAtBlockIDRequest) returns (ExecuteScriptResponse)
@@ -107,7 +107,7 @@ message ExecuteScriptResponse {
 
 `ExecuteScriptAtBlockHeight` executes a ready-only Cadence script against the execution state at the given block height.
 
-This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](https://developers.flow.com/cadence/json-cadence-spec).
 
 ```protobuf
 rpc ExecuteScriptAtBlockHeight (ExecuteScriptAtBlockHeightRequest) returns (ExecuteScriptResponse)

--- a/docs/content/nodes/archive-access-api.mdx
+++ b/docs/content/nodes/archive-access-api.mdx
@@ -1,0 +1,135 @@
+---
+title: Flow Archive Node Access API Specification
+sidebar_title: Archive Access API
+---
+
+The Archive Access API is implemented as a [gRPC service](https://grpc.io/).
+
+A language-agnostic specification for this API is defined using [Protocol Buffers](https://developers.google.com/protocol-buffers), which can be used to generate client libraries in a variety of programming languages.
+
+- [Flow Archive Access API protobuf source files](https://github.com/onflow/flow/tree/master/protobuf)
+
+## Flow archive node access endpoints
+
+The Archive Nodes hosted by DapperLabs are accessible at:
+
+#### Current Mainnet
+`archive.mainnet.nodes.onflow.org:9000`
+
+#### Sandboxnet
+
+`archive.sandboxnet.nodes.onflow.org:9000`
+
+#### Testnet
+
+`archive.devnet.nodes.onflow.org:9000`
+
+#### Canarynet
+
+`archive.canary.nodes.onflow.org:9000`
+
+#### Rate limits for Dapper Labs archive nodes
+
+Archive nodes operated by Dapper Labs are [rate limited](/nodes/archive-api-rate-limits).
+
+---
+
+## Accounts
+
+### GetAccountAtBlockHeight
+
+`GetAccountAtBlockHeight` gets an [account](#accounts) by address at the given block height.
+
+The archive node queries an execution node for the account details, which are stored as part of the execution state.
+
+```protobuf
+rpc GetAccountAtBlockHeight(GetAccountAtBlockHeightRequest) returns (AccountResponse)
+```
+
+
+#### Request
+
+```protobuf
+message GetAccountAtBlockHeightRequest {
+  bytes address
+  uint64 block_height
+}
+```
+
+
+
+
+#### Response
+
+```protobuf
+message AccountResponse {
+  Account account
+}
+```
+
+
+## Scripts
+
+### ExecuteScriptAtBlockID
+
+`ExecuteScriptAtBlockID` executes a ready-only Cadence script against the execution state at the block with the given ID.
+
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+
+```protobuf
+rpc ExecuteScriptAtBlockID (ExecuteScriptAtBlockIDRequest) returns (ExecuteScriptResponse)
+```
+
+
+#### Request
+
+```protobuf
+message ExecuteScriptAtBlockIDRequest {
+  bytes block_id
+  bytes script
+}
+```
+
+
+
+
+#### Response
+
+```protobuf
+message ExecuteScriptResponse {
+  bytes value
+}
+```
+
+
+
+### ExecuteScriptAtBlockHeight
+
+`ExecuteScriptAtBlockHeight` executes a ready-only Cadence script against the execution state at the given block height.
+
+This method can be used to read account state from the blockchain. The script is executed on an execution node and the return value is encoded using the [JSON-Cadence data interchange format](/cadence/json-cadence-spec).
+
+```protobuf
+rpc ExecuteScriptAtBlockHeight (ExecuteScriptAtBlockHeightRequest) returns (ExecuteScriptResponse)
+```
+
+
+#### Request
+
+```protobuf
+message ExecuteScriptAtBlockHeightRequest {
+  uint64 block_height
+  bytes script
+}
+```
+
+
+
+
+#### Response
+
+```protobuf
+message ExecuteScriptResponse {
+  bytes value
+}
+```

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -9,7 +9,7 @@ Following are the current rate limits for the [Archive Node gRPC API](archive-ac
 Once the limit has reached, the client will receive an RPC error `ResourceExhausted` in the gRPC response.
 
 Please note, these limits only apply to the archive nodes hosted by Dapper Labs. Archive nodes run by other node operators will have different rate limits.
-Also, all the gRPC endpoints listed below start with `flow.access.AccessAPI` due to the Archive Access API having the same gRPC protobuf definitions as the original Access API from our [Access Nodes](https://docs.onflow.org/nodes/node-operation/node-roles/#access).
+Also, all the gRPC endpoints listed below start with `flow.access.AccessAPI` due to the Archive Access API having the same gRPC protobuf definitions as the original Access API from our [Access Nodes](https://docs.onflow.org/nodes/node-operation/node-roles/#access). For information on rate limitting of the Access API for Flow's Access Nodes please visit [this page]((https://developers.flow.com/nodes/access-api-rate-limits)).
 
 ##### Mainnet
 

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -28,6 +28,5 @@ Also, all the gRPC endpoints listed below start with `flow.access.AccessAPI` due
 | flow.access.AccessAPI/ExecuteScriptAtBlockID         |                   1                           |
 | flow.access.AccessAPI/ExecuteScriptAtBlockHeight     |                   1                           |
 
-_The rate limits are the same for the gRPC web interface_
 
 

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -32,4 +32,3 @@ _The rate limits are the same for the gRPC web interface_
 
 _The rate limits for ALL the REST API is **40** request per second per client IP_
 
-Please note: The rate limits are applied by each of the archive nodes behind a load balancer and limits listed here are the aggregate total from all the archive nodes. Actual limits may be somewhat less depending on how the requests are routed.

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -30,5 +30,4 @@ Also, all the gRPC endpoints listed below start with `flow.access.AccessAPI` due
 
 _The rate limits are the same for the gRPC web interface_
 
-_The rate limits for ALL the REST API is **40** request per second per client IP_
 

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -1,0 +1,34 @@
+---
+title: Flow Archive Access API rate limits on Dapper Labs Archive nodes
+---
+
+#### Rate limits
+
+Following are the current rate limits for the [Archive Access Node gRPC API](archive-access-api) in total across all Dapper Labs Access nodes. The actual limits are enforced by each individual node. If you are using a load balanced endpoint, the limits below are the max rate, and may vary depending on how your requests are routed.
+
+Once the limit has reached, the client will receive an RPC error `ResourceExhausted` in the gRPC response.
+
+Please note, these limits only apply to the access nodes hosted by Dapper Labs. Access nodes run by other node operators will have different rate limits.
+
+##### Mainnet
+
+|                 gRPC API                             | Total request per second per client IP        |
+|:-----------------------------------------------------|:---------------------------------------------:|
+| flow.access.AccessAPI/GetAccountAtBlockHeight        |                   1                           |
+| flow.access.AccessAPI/ExecuteScriptAtBlockID         |                   1                           |
+| flow.access.AccessAPI/ExecuteScriptAtBlockHeight     |                   1                           |
+
+
+##### Testnet and Sandboxnet
+
+|                 gRPC API                             | Total request per second per IP               |
+|:-----------------------------------------------------|:---------------------------------------------:|
+| flow.access.AccessAPI/GetAccountAtLatestBlock        |                   1                           |
+| flow.access.AccessAPI/ExecuteScriptAtBlockID         |                   1                           |
+| flow.access.AccessAPI/ExecuteScriptAtBlockHeight     |                   1                           |
+
+_The rate limits are the same for the gRPC web interface_
+
+_The rate limits for ALL the REST API is **40** request per second per client IP_
+
+Please note: The rate limits are applied by each of the access nodes behind a load balancer and limits listed here are the aggregate total from all the archive nodes. Actual limits may be somewhat less depending on how the requests are routed.

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -9,6 +9,7 @@ Following are the current rate limits for the [Archive Node gRPC API](archive-ac
 Once the limit has reached, the client will receive an RPC error `ResourceExhausted` in the gRPC response.
 
 Please note, these limits only apply to the archive nodes hosted by Dapper Labs. Archive nodes run by other node operators will have different rate limits.
+Also, all the gRPC endpoints listed below start with `flow.access.AccessAPI` due to the Archive Access API having the same gRPC protobuf definitions as the original Access API from our [Access Nodes](https://docs.onflow.org/nodes/node-operation/node-roles/#access).
 
 ##### Mainnet
 

--- a/docs/content/nodes/archive-api-rate-limits.mdx
+++ b/docs/content/nodes/archive-api-rate-limits.mdx
@@ -4,11 +4,11 @@ title: Flow Archive Access API rate limits on Dapper Labs Archive nodes
 
 #### Rate limits
 
-Following are the current rate limits for the [Archive Access Node gRPC API](archive-access-api) in total across all Dapper Labs Access nodes. The actual limits are enforced by each individual node. If you are using a load balanced endpoint, the limits below are the max rate, and may vary depending on how your requests are routed.
+Following are the current rate limits for the [Archive Node gRPC API](archive-access-api) in total across all Dapper Labs Archive nodes. The actual limits are enforced by each individual node. If you are using a load balanced endpoint, the limits below are the max rate, and may vary depending on how your requests are routed.
 
 Once the limit has reached, the client will receive an RPC error `ResourceExhausted` in the gRPC response.
 
-Please note, these limits only apply to the access nodes hosted by Dapper Labs. Access nodes run by other node operators will have different rate limits.
+Please note, these limits only apply to the archive nodes hosted by Dapper Labs. Archive nodes run by other node operators will have different rate limits.
 
 ##### Mainnet
 
@@ -31,4 +31,4 @@ _The rate limits are the same for the gRPC web interface_
 
 _The rate limits for ALL the REST API is **40** request per second per client IP_
 
-Please note: The rate limits are applied by each of the access nodes behind a load balancer and limits listed here are the aggregate total from all the archive nodes. Actual limits may be somewhat less depending on how the requests are routed.
+Please note: The rate limits are applied by each of the archive nodes behind a load balancer and limits listed here are the aggregate total from all the archive nodes. Actual limits may be somewhat less depending on how the requests are routed.


### PR DESCRIPTION
Closes: [#onflow/flow-archive/22](https://github.com/onflow/flow-archive/issues/22)

## Description
Add new Archive node v1 Access API docs and instructions to run.
