### PR TITLE
Changed to `flow init` from `flow project init`

### DIFF
--- a/docs/content/dapp-development/testnet-deployment.md
+++ b/docs/content/dapp-development/testnet-deployment.md
@@ -74,7 +74,7 @@ It may be necessary to create additional accounts for testing purposes and you c
 First you need to initialize the configuration:
 
 ```
-> flow project init
+> flow init
 ```
 
 Add the account created with the use of faucet above to the `accounts` property in configuration, like so:


### PR DESCRIPTION
`flow project init` doesn't exist. Changed to `flow init`

Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
