### PR TITLE
Update boot-tool shas for v0.29

### DIFF
--- a/docs/content/node-operation/node-bootstrap.mdx
+++ b/docs/content/node-operation/node-bootstrap.mdx
@@ -41,10 +41,10 @@ tar -xvf boot-tools.tar
 
 ```shell:title=CheckSHA256
 sha256sum ./boot-tools/bootstrap
-5da13e35c05333024b31e1310276498e62b2601cb303b1c447781bfaf7b14d72  ./boot-tools/bootstrap
+977e9d0139bac303a8fcfc78f9a1de6d2513410082dbfa22bbbd0408d4ed7e15  ./boot-tools/bootstrap
 
 sha256sum ./boot-tools/transit
-1be57b940397ecb9418da9de05f87302e9512c4d6ca658ed2c4d17a38446a9f3  ./boot-tools/transit
+81c10386ae80196561098dfdb682aef8f4d8be882e22d92f097a88060c783f0c  ./boot-tools/transit
 ```
 
 ### Generate Your Node Keys


### PR DESCRIPTION
## Description

Update the SHAs listed for the node bootstrapping `boot-tool` to match the `v0.29` versions

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
