### PR TITLE
Fixing broken relative links and fixing external links (outside of doc root)

### DIFF
--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -22,7 +22,7 @@ interact with FLOW.
 There are currently several ways to acquire FLOW tokens:
 
 1. [Claim FLOW as a Backer](./delivery.mdx): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](/staking/technical-overview.mdx): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Validator](../staking/technical-overview.mdx): Receive newly-minted FLOW as a reward for running a node.
 1. [Earn FLOW as a Platform Contributor](./earn.mdx): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -47,12 +47,12 @@ and then sign with the wallet of your choice only once you decide to make a purc
 
 ### Staking FLOW
 
-[You can use FLOW to operate a staked node.](/staking) Node operators receive newly-minted FLOW
+[You can use FLOW to operate a staked node.](../staking) Node operators receive newly-minted FLOW
 as a reward for helping to secure the network.
 
 ### Delegating FLOW
 
-[You can use FLOW for stake delegation.](/staking) Delegators receive newly-minted FLOW
+[You can use FLOW for stake delegation.](../staking) Delegators receive newly-minted FLOW
 as a reward for helping to secure the network.
 
 ### Holding FLOW

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -21,9 +21,9 @@ interact with FLOW.
 
 There are currently several ways to acquire FLOW tokens:
 
-1. [Claim FLOW as a Backer](./delivery): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
-1. [Earn FLOW as a Platform Contributor](./earn): Receive newly-minted FLOW as a reward for building on Flow.
+1. [Claim FLOW as a Backer](./delivery.mdx): Existing Flow backers can claim their FLOW.
+1. [Earn FLOW as a Validator](/staking/technical-overview.mdx): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Platform Contributor](./earn.mdx): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW
 

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -22,7 +22,7 @@ interact with FLOW.
 There are currently several ways to acquire FLOW tokens:
 
 1. [Claim FLOW as a Backer](./delivery): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](/nodes/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Validator](nodes/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
 1. [Earn FLOW as a Platform Contributor](./earn): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -22,7 +22,7 @@ interact with FLOW.
 There are currently several ways to acquire FLOW tokens:
 
 1. [Claim FLOW as a Backer](./delivery): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](nodes/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Validator](/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
 1. [Earn FLOW as a Platform Contributor](./earn): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -110,4 +110,4 @@ The Flow SDKs also allow polling for events using the Flow Access API,
 
 ## How to Build with FLOW
 
-To get started building on Flow, please read the [Flow Developer Onboarding guide](/dapp-development/).
+To get started building on Flow, please read the [Flow Developer Onboarding guide](../dapp-development).

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -21,9 +21,9 @@ interact with FLOW.
 
 There are currently several ways to acquire FLOW tokens:
 
-1. [Claim FLOW as a Backer](/flow-token/delivery): Existing Flow backers can claim their FLOW.
+1. [Claim FLOW as a Backer](./delivery): Existing Flow backers can claim their FLOW.
 1. [Earn FLOW as a Validator](/staking/technical-overview/): Receive newly-minted FLOW as a reward for running a node.
-1. [Earn FLOW as a Platform Contributor](/flow-token/earn): Receive newly-minted FLOW as a reward for building on Flow.
+1. [Earn FLOW as a Platform Contributor](./earn): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW
 

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -22,7 +22,7 @@ interact with FLOW.
 There are currently several ways to acquire FLOW tokens:
 
 1. [Claim FLOW as a Backer](./delivery.mdx): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](../staking/technical-overview.mdx): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Validator](https://developers.flow.com/nodes/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
 1. [Earn FLOW as a Platform Contributor](./earn.mdx): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW
@@ -47,12 +47,12 @@ and then sign with the wallet of your choice only once you decide to make a purc
 
 ### Staking FLOW
 
-[You can use FLOW to operate a staked node.](../staking) Node operators receive newly-minted FLOW
+[You can use FLOW to operate a staked node.](https://developers.flow.com/nodes/staking/technical-overview) Node operators receive newly-minted FLOW
 as a reward for helping to secure the network.
 
 ### Delegating FLOW
 
-[You can use FLOW for stake delegation.](../staking) Delegators receive newly-minted FLOW
+[You can use FLOW for stake delegation.](https://developers.flow.com/nodes/staking/technical-overview) Delegators receive newly-minted FLOW
 as a reward for helping to secure the network.
 
 ### Holding FLOW
@@ -110,4 +110,4 @@ The Flow SDKs also allow polling for events using the Flow Access API,
 
 ## How to Build with FLOW
 
-To get started building on Flow, please read the [Flow Developer Onboarding guide](../dapp-development).
+To get started building on Flow, please read the [Flow Developer Onboarding guide](https://developers.flow.com/flow/dapp-development).

--- a/docs/content/flow-token/index.mdx
+++ b/docs/content/flow-token/index.mdx
@@ -22,7 +22,7 @@ interact with FLOW.
 There are currently several ways to acquire FLOW tokens:
 
 1. [Claim FLOW as a Backer](./delivery): Existing Flow backers can claim their FLOW.
-1. [Earn FLOW as a Validator](/staking/technical-overview/): Receive newly-minted FLOW as a reward for running a node.
+1. [Earn FLOW as a Validator](/nodes/staking/technical-overview): Receive newly-minted FLOW as a reward for running a node.
 1. [Earn FLOW as a Platform Contributor](./earn): Receive newly-minted FLOW as a reward for building on Flow.
 
 ## How to Use FLOW


### PR DESCRIPTION
Testing relative link fix

References:  https://github.com/onflow/developer-portal/issues/735

## Description

relative links are broken, this is complicated by flow-token directly is a root url. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
