### PR TITLE
Remove old transaction from locked-tokens.mdx

### DIFF
--- a/docs/content/core-contracts/locked-tokens.mdx
+++ b/docs/content/core-contracts/locked-tokens.mdx
@@ -55,10 +55,10 @@ accounts to hold locked FLOW.
 
 | ID          | Name                    | Source                                                                                                                                                                              |
 | ----------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`TA.01`** | Created Shared Account  | [lockedTokens/admin/admin_create_shared_accounts.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_create_shared_accounts.cdc)   |
-| **`TA.02`** | Deposit Locked Tokens   | [lockedTokens/admin/deposit_locked_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/deposit_locked_tokens.cdc)                 |
-| **`TA.03`** | Unlock Tokens           | [lockedTokens/admin/unlock_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/unlock_tokens.cdc)                                 |
-| **`TA.04`** | Deposit Account Creator | [lockedTokens/admin/admin_deposit_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_deposit_account_creator.cdc) |
+| **`TA.02`** | Created Shared Account  | [lockedTokens/admin/admin_create_shared_accounts.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_create_shared_accounts.cdc)   |
+| **`TA.04`** | Deposit Locked Tokens   | [lockedTokens/admin/deposit_locked_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/deposit_locked_tokens.cdc)                 |
+| **`TA.05`** | Unlock Tokens           | [lockedTokens/admin/unlock_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/unlock_tokens.cdc)                                 |
+| **`TA.06`** | Deposit Account Creator | [lockedTokens/admin/admin_deposit_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_deposit_account_creator.cdc) |
 
 ## Custodian
 

--- a/docs/content/core-contracts/locked-tokens.mdx
+++ b/docs/content/core-contracts/locked-tokens.mdx
@@ -55,11 +55,10 @@ accounts to hold locked FLOW.
 
 | ID          | Name                    | Source                                                                                                                                                                              |
 | ----------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`TA.01`** | Set Up Admin Account    | [lockedTokens/admin/create_admin_collection.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/create_admin_collection.cdc)             |
-| **`TA.02`** | Created Shared Account  | [lockedTokens/admin/admin_create_shared_accounts.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_create_shared_accounts.cdc)   |
-| **`TA.04`** | Deposit Locked Tokens   | [lockedTokens/admin/deposit_locked_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/deposit_locked_tokens.cdc)                 |
-| **`TA.05`** | Unlock Tokens           | [lockedTokens/admin/unlock_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/unlock_tokens.cdc)                                 |
-| **`TA.06`** | Deposit Account Creator | [lockedTokens/admin/admin_deposit_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_deposit_account_creator.cdc) |
+| **`TA.01`** | Created Shared Account  | [lockedTokens/admin/admin_create_shared_accounts.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_create_shared_accounts.cdc)   |
+| **`TA.02`** | Deposit Locked Tokens   | [lockedTokens/admin/deposit_locked_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/deposit_locked_tokens.cdc)                 |
+| **`TA.03`** | Unlock Tokens           | [lockedTokens/admin/unlock_tokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/unlock_tokens.cdc)                                 |
+| **`TA.04`** | Deposit Account Creator | [lockedTokens/admin/admin_deposit_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_deposit_account_creator.cdc) |
 
 ## Custodian
 


### PR DESCRIPTION
create_admin_collection does not exist any more

Closes: #???

https://github.com/onflow/flow-core-contracts/issues/338
## Description
This page on dev portal: 
https://developers.flow.com/flow/core-contracts/locked-tokens	

references this transaction that no longer exists in github.  https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/create_admin_collection.cdc
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
