### PR TITLE
adds emulator and canary import addresses to docs site

### DIFF
--- a/docs/content/core-contracts/epoch-contract-reference.mdx
+++ b/docs/content/core-contracts/epoch-contract-reference.mdx
@@ -15,11 +15,12 @@ Sources:
 - [FlowClusterQC.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/epochs/FlowClusterQC.cdc)
 - [FlowDKG.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/epochs/FlowDKG.cdc)
 
-| Network    | Contract Address     |
-|------------|----------------------|
-| Testnet    | `0x9eca2b38b18b5dfe` |
-| Sandboxnet | `0xf4527793ee68aede` |
-| Mainnet    | `0x8624b52f9ddcd04a` |
+| Network         | Contract Address     |
+|-----------------|----------------------|
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x9eca2b38b18b5dfe` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0x8624b52f9ddcd04a` |
 
 # Transactions
 

--- a/docs/content/core-contracts/flow-fees.mdx
+++ b/docs/content/core-contracts/flow-fees.mdx
@@ -7,8 +7,21 @@ The `FlowFees` contract is where all the collected flow fees are gathered.
 
 Source: [FlowFees.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowFees.cdc)
 
-| Network    | Contract Address     |
-| ---------- | -------------------- |
-| Testnet    | `0x912d5440f7e3769e` |
-| Sandboxnet | `0xe92c2039bbe9da96` |
-| Mainnet    | `0xf919ee77447b7497` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xe5a8b7f23e8b548f` |
+| Testnet         | `0x912d5440f7e3769e` |
+| Sandboxnet      | `0xe92c2039bbe9da96` |
+| Mainnet         | `0xf919ee77447b7497` |
+
+
+The `FlowStorageFees` contract defines the parameters and utility methods for storage fees.
+
+Source: [FlowFees.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowStorageFees.cdc)
+
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x8c5303eaa26202d6` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0xe467b9dd11fa00df` |

--- a/docs/content/core-contracts/flow-token.mdx
+++ b/docs/content/core-contracts/flow-token.mdx
@@ -7,12 +7,12 @@ The `FlowToken` contract defines the FLOW network token.
 
 Source: [FlowToken.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowToken.cdc)
 
-| Network     | Contract Address     |
-| ----------- | -------------------- |
-| Emulator    | `0x0ae53cb6e3f42a79` |
-| Testnet     | `0x7e60df042a9c0868` |
-| Sandboxnet  | `0x0661ab7d6696a460` |
-| Mainnet     | `0x1654653399040a61` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0x0ae53cb6e3f42a79` |
+| Testnet         | `0x7e60df042a9c0868` |
+| Sandboxnet      | `0x0661ab7d6696a460` |
+| Mainnet         | `0x1654653399040a61` |
 
 # Transactions
 

--- a/docs/content/core-contracts/fungible-token.mdx
+++ b/docs/content/core-contracts/fungible-token.mdx
@@ -7,10 +7,10 @@ The `FungibleToken` contract implements the Fungible Token Standard. It is the s
 
 Source: [FungibleToken.cdc](https://github.com/onflow/flow-ft/blob/master/contracts/FungibleToken.cdc)
 
-| Network    | Contract Address     |
-| ---------- | -------------------- |
-| Emulator   | `0xee82856bf20e2aa6` |
-| Testnet    | `0x9a0766d93b6608b7` |
-| Sandboxnet | `0xe20612a0776ca4bf` |
-| Mainnet    | `0xf233dcee88fe0abe` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xee82856bf20e2aa6` |
+| Testnet         | `0x9a0766d93b6608b7` |
+| Sandboxnet      | `0xe20612a0776ca4bf` |
+| Mainnet         | `0xf233dcee88fe0abe` |
 

--- a/docs/content/core-contracts/locked-tokens.mdx
+++ b/docs/content/core-contracts/locked-tokens.mdx
@@ -22,12 +22,12 @@ and **node operators** perform staking operations with locked FLOW.
 
 Source: [StakingProxy.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/StakingProxy.cdc)
 
-| Network    | Contract Address     |
-| ---------- | -------------------- |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
 | Emulator/Canary | `0xf8d6e0586b0a20c7` |
-| Testnet    | `0x7aad92e5a0715d21` |
-| Sandboxnet | `0xf4527793ee68aede` |
-| Mainnet    | `0x62430cf28c26d095` |
+| Testnet         | `0x7aad92e5a0715d21` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0x62430cf28c26d095` |
 
 # Transactions
 

--- a/docs/content/core-contracts/locked-tokens.mdx
+++ b/docs/content/core-contracts/locked-tokens.mdx
@@ -8,11 +8,12 @@ used to store locked FLOW tokens owned by a token holder.
 
 Source: [LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc)
 
-| Network    | Contract Address     |
-| ---------- | -------------------- |
-| Testnet    | `0x95e019a17d0e23d7` |
-| Sandboxnet | `0xf4527793ee68aede` |
-| Mainnet    | `0x8d0e87b65159ae63` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x95e019a17d0e23d7` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0x8d0e87b65159ae63` |
 
 ## StakingProxy
 
@@ -23,6 +24,7 @@ Source: [StakingProxy.cdc](https://github.com/onflow/flow-core-contracts/blob/ma
 
 | Network    | Contract Address     |
 | ---------- | -------------------- |
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
 | Testnet    | `0x7aad92e5a0715d21` |
 | Sandboxnet | `0xf4527793ee68aede` |
 | Mainnet    | `0x62430cf28c26d095` |

--- a/docs/content/core-contracts/non-fungible-token.mdx
+++ b/docs/content/core-contracts/non-fungible-token.mdx
@@ -8,8 +8,9 @@ All NFT contracts are encouraged to import and implement this standard.
 
 Source: [NonFungibleToken.cdc](https://github.com/onflow/flow-nft/blob/master/contracts/NonFungibleToken.cdc)
 
-| Network    | Contract Address     |
-| ---------- | -------------------- |
-| Testnet    | `0x631e88ae7f1d7c20` |
-| Sandboxnet | `0x83ade3a54eb3870c` |
-| Mainnet    | `0x1d7e57aa55817448` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x631e88ae7f1d7c20` |
+| Sandboxnet      | `0x83ade3a54eb3870c` |
+| Mainnet         | `0x1d7e57aa55817448` |

--- a/docs/content/core-contracts/service-account.mdx
+++ b/docs/content/core-contracts/service-account.mdx
@@ -11,13 +11,9 @@ some convenience methods for Flow Token operations.
 
 Source: [FlowServiceAccount.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc)
 
-- `FlowStorageFees` defines and implements the rules and methods for how accounts pay for their storage usage.
-
-Source: [FlowStorageFees.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowStorageFees.cdc)
-
-| Network    | Contract Address     |
-| ---------- | -------------------- |
-| Emulator   | `0xf8d6e0586b0a20c7` |
-| Testnet    | `0x8c5303eaa26202d6` |
-| Sandboxnet | `0xf4527793ee68aede` |
-| Mainnet    | `0xe467b9dd11fa00df` |
+| Network         | Contract Address     |
+| --------------- | -------------------- |
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x8c5303eaa26202d6` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0xe467b9dd11fa00df` |

--- a/docs/content/core-contracts/staking-contract-reference.mdx
+++ b/docs/content/core-contracts/staking-contract-reference.mdx
@@ -10,7 +10,7 @@ The `FlowIDTableStaking` contract is the central table that manages staked nodes
 Source: [FlowIDTableStaking.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc)
 
 | Network         | Contract Address     |
-|-----------------|----------------------|
+| --------------- | -------------------- |
 | Emulator/Canary | `0xf8d6e0586b0a20c7` |
 | Testnet         | `0x9eca2b38b18b5dfe` |
 | Sandboxnet      | `0xf4527793ee68aede` |

--- a/docs/content/core-contracts/staking-contract-reference.mdx
+++ b/docs/content/core-contracts/staking-contract-reference.mdx
@@ -9,11 +9,12 @@ The `FlowIDTableStaking` contract is the central table that manages staked nodes
 
 Source: [FlowIDTableStaking.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowIDTableStaking.cdc)
 
-| Network    | Contract Address     |
-|------------|----------------------|
-| Testnet    | `0x9eca2b38b18b5dfe` |
-| Sandboxnet | `0xf4527793ee68aede` |
-| Mainnet    | `0x8624b52f9ddcd04a` |
+| Network         | Contract Address     |
+|-----------------|----------------------|
+| Emulator/Canary | `0xf8d6e0586b0a20c7` |
+| Testnet         | `0x9eca2b38b18b5dfe` |
+| Sandboxnet      | `0xf4527793ee68aede` |
+| Mainnet         | `0x8624b52f9ddcd04a` |
 
 # Transactions
 


### PR DESCRIPTION
## Description

Adds standard import addresses for canary and emulator networks to the core contracts pages

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
