### PR TITLE
fix yaml indentation

### DIFF
--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -19,18 +19,18 @@ The flow-go application doesn't expose any metrics from the underlying host such
 
 1. Copy the following Prometheus configuration into your current flow node
    ```yml:title=prometheus.yml
-   global:
-      scrape_interval: 15s # By default, scrape targets every 15 seconds.
+  global:
+    scrape_interval: 15s # By default, scrape targets every 15 seconds.
 
-   scrape_configs:
+  scrape_configs:
     # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-      - job_name: 'prometheus'
+    - job_name: 'prometheus'
 
     # Override the global default and scrape targets from this job every 5 seconds.
-      scrape_interval: 5s
+    scrape_interval: 5s
 
-      static_configs:
-         - targets: ['localhost:8080']
+    static_configs:
+      - targets: ['localhost:8080']
    ```
 
 2. Start Prometheus server

--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -20,17 +20,17 @@ The flow-go application doesn't expose any metrics from the underlying host such
 1. Copy the following Prometheus configuration into your current flow node
    ```yml:title=prometheus.yml
    global:
-   scrape_interval: 15s # By default, scrape targets every 15 seconds.
+      scrape_interval: 15s # By default, scrape targets every 15 seconds.
 
    scrape_configs:
     # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-    - job_name: 'prometheus'
+      - job_name: 'prometheus'
 
     # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
+      scrape_interval: 5s
 
-    static_configs:
-     - targets: ['localhost:8080']
+      static_configs:
+         - targets: ['localhost:8080']
    ```
 
 2. Start Prometheus server


### PR DESCRIPTION
Closes: #???

## Description

Supplied yaml for prometheus is invalid

specifically `scrape_interval` and `static_configs` elements belong to the prometheus "job" and need to be indented as such
-->

First time contributing tho this Repo let me know if there's any additional info I can provide

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
