### PR TITLE
Fix an incorrect metric name in node monitoring page

### DIFF
--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -53,7 +53,7 @@ The following are some important metrics produced by the node
 | Metric Name                                | Description                                                       |
 |--------------------------------------------|-------------------------------------------------------------------|
 | go_*                                       | Go runtime metrics                                                |
-| consensus_finalized_blocks                 | Number of blocks this node has finalized                          |
+| consensus_compliance_finalized_height      | Latest height finalized by this node                              |
 | consensus_hotstuff_busy_duration           | How long Hotstuff spends in a busy state before returning to idle |
 | consensus_hostuff_busy_second_total        | The total time Hotstuff has spent in a busy state                 |
 | consensus_hotstuff_view_of_newest_known_qc | The latest block known to Hotstuff                                |


### PR DESCRIPTION
Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
