### PR TITLE
Update monitoring-nodes.mdx

### DIFF
--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -57,4 +57,3 @@ The following are some important metrics produced by the node
 | consensus_hotstuff_busy_duration           | How long Hotstuff spends in a busy state before returning to idle |
 | consensus_hostuff_busy_second_total        | The total time Hotstuff has spent in a busy state                 |
 | consensus_hotstuff_view_of_newest_known_qc | The latest block known to Hotstuff                                |
-Copy the following 

--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -18,29 +18,29 @@ The flow-go application doesn't expose any metrics from the underlying host such
 </Callout>
 
 1. Copy the following Prometheus configuration into your current flow node
-   ```
-  global:
-    scrape_interval: 15s # By default, scrape targets every 15 seconds.
-
-  scrape_configs:
-    # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-    - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
-
-    static_configs:
-      - targets: ['localhost:8080']
+   ```yaml
+      global:
+        scrape_interval: 15s # By default, scrape targets every 15 seconds.
+    
+      scrape_configs:
+        # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+        - job_name: 'prometheus'
+    
+        # Override the global default and scrape targets from this job every 5 seconds.
+        scrape_interval: 5s
+    
+        static_configs:
+          - targets: ['localhost:8080']
    ```
 
 2. Start Prometheus server
-```
-   docker run \
-   --network=host \
-   -p 9090:9090 \
-   -v /path/to/prometheus.yml:/etc/prometheus/prometheus.yml \
-   prom/prometheus"
-```
+    ```shell
+       docker run \
+       --network=host \
+       -p 9090:9090 \
+       -v /path/to/prometheus.yml:/etc/prometheus/prometheus.yml \
+       prom/prometheus"
+    ```
 3. (optional) Port forward to the node if you are not able to access port 9090 directly via the browser
    `ssh -L 9090:127.0.0.1:9090 YOUR_NODE`
 
@@ -57,4 +57,4 @@ The following are some important metrics produced by the node
 | consensus_hotstuff_busy_duration           | How long Hotstuff spends in a busy state before returning to idle |
 | consensus_hostuff_busy_second_total        | The total time Hotstuff has spent in a busy state                 |
 | consensus_hotstuff_view_of_newest_known_qc | The latest block known to Hotstuff                                |
-
+Copy the following 


### PR DESCRIPTION
formatting of syntax highlighting not rendering correctly

References: https://github.com/onflow/developer-portal/issues/968

## Description

Github having issues rendering markdown, updating formatting so it renders correctly

<img width="1178" alt="Screenshot 2023-03-03 at 9 29 00 AM" src="https://user-images.githubusercontent.com/3970376/222775902-592a5eb0-f471-4862-8e02-8432478fdabc.png">



______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
