### PR TITLE
Update notable metrics list

### DIFF
--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -56,4 +56,4 @@ The following are some important metrics produced by the node.
 | consensus_compliance_finalized_height      | Latest height finalized by this node; should increase at a constant rate. |
 | consensus_compliance_sealed_height         | Latest height sealed by this node; should increase at a constant rate. |
 | consensus_hotstuff_cur_view                | Current view of the HotStuff consensus algorith; Consensus/Collection only; should increase at a constant rate. |
-| consensus_hotstuff_timeout_seconds         | How long it takes to timeout failed rounds; Consensus/Collection only; values larger than 5s are abnormal. |
+| consensus_hotstuff_timeout_seconds         | How long it takes to timeout failed rounds; Consensus/Collection only; values consistently larger than 5s are abnormal. |

--- a/docs/content/node-operation/monitoring-nodes.mdx
+++ b/docs/content/node-operation/monitoring-nodes.mdx
@@ -48,12 +48,12 @@ The flow-go application doesn't expose any metrics from the underlying host such
 
 ## Key Metric Overview
 
-The following are some important metrics produced by the node
+The following are some important metrics produced by the node.
 
 | Metric Name                                | Description                                                       |
 |--------------------------------------------|-------------------------------------------------------------------|
 | go_*                                       | Go runtime metrics                                                |
-| consensus_compliance_finalized_height      | Latest height finalized by this node                              |
-| consensus_hotstuff_busy_duration           | How long Hotstuff spends in a busy state before returning to idle |
-| consensus_hostuff_busy_second_total        | The total time Hotstuff has spent in a busy state                 |
-| consensus_hotstuff_view_of_newest_known_qc | The latest block known to Hotstuff                                |
+| consensus_compliance_finalized_height      | Latest height finalized by this node; should increase at a constant rate. |
+| consensus_compliance_sealed_height         | Latest height sealed by this node; should increase at a constant rate. |
+| consensus_hotstuff_cur_view                | Current view of the HotStuff consensus algorith; Consensus/Collection only; should increase at a constant rate. |
+| consensus_hotstuff_timeout_seconds         | How long it takes to timeout failed rounds; Consensus/Collection only; values larger than 5s are abnormal. |


### PR DESCRIPTION
Proposing a more actionable set of key metrics on the node monitoring page; noting which metrics are consensus-only. 