### PR TITLE
[Node Setup] Add default flags to set execution data directory for EN/AN

### DIFF
--- a/docs/content/node-operation/node-setup.mdx
+++ b/docs/content/node-operation/node-setup.mdx
@@ -103,6 +103,7 @@ docker run --rm \
 	--bootstrapdir=/bootstrap \
 	--datadir=/data/protocol \
 	--secretsdir=/data/secrets \
+	--execution-data-dir=/data/execution_data \
 	--rpc-addr=0.0.0.0:9000 \
 	--http-addr=0.0.0.0:8000 \
 	--collection-ingress-port=9000 \
@@ -163,6 +164,7 @@ docker run --rm \
 	--datadir=/data/protocol \
 	--secretsdir=/data/secrets \
 	--triedir=/data/execution \
+	--execution-data-dir=/data/execution_data \
 	--rpc-addr=0.0.0.0:9000 \
 	--bind 0.0.0.0:3569 \
 	--loglevel=error


### PR DESCRIPTION
Closes: #???

## Description

Adds `--execution-data-dir` to the example docker flags for ENs and ANs. This specifies where execution data should be stored. By default, the data is stored within the docker container.
