### PR TITLE
fix(sporks.json): change accessNode for previous spork

### DIFF
--- a/sporks.json
+++ b/sporks.json
@@ -86,7 +86,7 @@
           }
         ],
         "accessNodes": [
-          "access.mainnet.nodes.onflow.org:9000"
+          "access-001.mainnet22.nodes.onflow.org:9000"
         ]
       },
       "mainnet21": {


### PR DESCRIPTION
Closes: #???

## Description

There are two similar `accessNode` set for mainnet23 and mainnet22 in `sparts.json` config
It is incorrect since `mainnet22` is no longer mainnet.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
