### PR TITLE
[AccessAPI] Add missing block payloads and account keys endpoints

### DIFF
--- a/openapi/access.yaml
+++ b/openapi/access.yaml
@@ -93,6 +93,35 @@ paths:
           $ref: '#/components/responses/404NotFound'
         '500':
           $ref: '#/components/responses/500InternalServerError'
+  /blocks/{id}/payload:
+    get:
+      summary: Get Block Payload by Block ID.
+      description: Get a block payload data by the provided block ID.
+      tags:
+        - Blocks
+      parameters:
+        - description: A block ID.
+          name: id
+          in: path
+          schema:
+            $ref: '#/components/schemas/Identifier'
+          explode: true
+          required: true
+        - $ref: '#/components/parameters/expandParam'
+        - $ref: '#/components/parameters/selectParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockPayload'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /transactions/{id}:
     get:
       summary: Get a Transaction by ID.
@@ -346,6 +375,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Account'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+  /accounts/{address}/keys/{index}:
+    get:
+      summary: Get an individual Account Key By Address and Index
+      description: Get an account data by provided address in latest "sealed" block or by provided block height.
+      tags:
+        - Accounts
+      parameters:
+        - name: address
+          in: path
+          schema:
+            $ref: '#/components/schemas/Address'
+          required: true
+          description: The address of the account.
+        - name: index
+          in: path
+          schema:
+            type: string
+            format: uint64
+            description: Index of the public key.
+          required: true
+          description: The index of the account key.
+        - name: block_height
+          in: query
+          schema:
+            $ref: '#/components/schemas/BlockHeight'
+          required: false
+          description: The block height to query for the account details at the "sealed" is used by default.
+        - $ref: '#/components/parameters/expandParam'
+        - $ref: '#/components/parameters/selectParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPublicKey'
         '400':
           $ref: '#/components/responses/400BadRequest'
         '404':

--- a/openapi/go-client-generated/README.md
+++ b/openapi/go-client-generated/README.md
@@ -22,8 +22,10 @@ All URIs are relative to *https://rest-canary.onflow.org/v1/*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AccountsApi* | [**AccountsAddressGet**](docs/AccountsApi.md#accountsaddressget) | **Get** /accounts/{address} | Get an Account By Address
+*AccountsApi* | [**AccountsAddressKeysIndexGet**](docs/AccountsApi.md#accountsaddresskeysindexget) | **Get** /accounts/{address}/keys/{index} | Get an individual Account Key By Address and Index
 *BlocksApi* | [**BlocksGet**](docs/BlocksApi.md#blocksget) | **Get** /blocks | Gets Blocks by Height
 *BlocksApi* | [**BlocksIdGet**](docs/BlocksApi.md#blocksidget) | **Get** /blocks/{id} | Get Blocks by ID.
+*BlocksApi* | [**BlocksIdPayloadGet**](docs/BlocksApi.md#blocksidpayloadget) | **Get** /blocks/{id}/payload | Get Block Payload by Block ID.
 *CollectionsApi* | [**CollectionsIdGet**](docs/CollectionsApi.md#collectionsidget) | **Get** /collections/{id} | Gets a Collection by ID
 *EventsApi* | [**EventsGet**](docs/EventsApi.md#eventsget) | **Get** /events | Get Events
 *ExecutionResultsApi* | [**ExecutionResultsGet**](docs/ExecutionResultsApi.md#executionresultsget) | **Get** /execution_results | Get Execution Results by Block ID

--- a/openapi/go-client-generated/api/swagger.yaml
+++ b/openapi/go-client-generated/api/swagger.yaml
@@ -180,6 +180,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /blocks/{id}/payload:
+    get:
+      tags:
+      - Blocks
+      summary: Get Block Payload by Block ID.
+      description: Get a block payload data by the provided block ID.
+      parameters:
+      - name: id
+        in: path
+        description: A block ID.
+        required: true
+        style: simple
+        explode: true
+        schema:
+          $ref: '#/components/schemas/Identifier'
+      - name: expand
+        in: query
+        description: A comma-separated list indicating which properties of the content
+          to expand.
+        required: false
+        style: form
+        explode: false
+        schema:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      - name: select
+        in: query
+        description: A comma-separated list indicating which properties of the content
+          to return.
+        required: false
+        style: form
+        explode: false
+        schema:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockPayload'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /transactions/{id}:
     get:
       tags:
@@ -623,6 +689,92 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Account'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /accounts/{address}/keys/{index}:
+    get:
+      tags:
+      - Accounts
+      summary: Get an individual Account Key By Address and Index
+      description: Get an account data by provided address in latest "sealed" block
+        or by provided block height.
+      parameters:
+      - name: address
+        in: path
+        description: The address of the account.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          $ref: '#/components/schemas/Address'
+      - name: index
+        in: path
+        description: The index of the account key.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+          description: Index of the public key.
+          format: uint64
+      - name: block_height
+        in: query
+        description: The block height to query for the account details at the "sealed"
+          is used by default.
+        required: false
+        style: form
+        explode: true
+        schema:
+          $ref: '#/components/schemas/BlockHeight'
+      - name: expand
+        in: query
+        description: A comma-separated list indicating which properties of the content
+          to expand.
+        required: false
+        style: form
+        explode: false
+        schema:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      - name: select
+        in: query
+        description: A comma-separated list indicating which properties of the content
+          to return.
+        required: false
+        style: form
+        explode: false
+        schema:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPublicKey'
         "400":
           description: Bad Request
           content:

--- a/openapi/go-client-generated/api_accounts.go
+++ b/openapi/go-client-generated/api_accounts.go
@@ -160,3 +160,140 @@ func (a *AccountsApiService) AccountsAddressGet(ctx context.Context, address str
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
+/*
+AccountsApiService Get an individual Account Key By Address and Index
+Get an account data by provided address in latest \&quot;sealed\&quot; block or by provided block height.
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param address The address of the account.
+ * @param index The index of the account key.
+ * @param optional nil or *AccountsApiAccountsAddressKeysIndexGetOpts - Optional Parameters:
+     * @param "BlockHeight" (optional.Interface of BlockHeight) -  The block height to query for the account details at the \&quot;sealed\&quot; is used by default.
+     * @param "Expand" (optional.Interface of []string) -  A comma-separated list indicating which properties of the content to expand.
+     * @param "Select_" (optional.Interface of []string) -  A comma-separated list indicating which properties of the content to return.
+@return AccountPublicKey
+*/
+
+type AccountsApiAccountsAddressKeysIndexGetOpts struct {
+    BlockHeight optional.Interface
+    Expand optional.Interface
+    Select_ optional.Interface
+}
+
+func (a *AccountsApiService) AccountsAddressKeysIndexGet(ctx context.Context, address string, index string, localVarOptionals *AccountsApiAccountsAddressKeysIndexGetOpts) (AccountPublicKey, *http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Get")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		localVarReturnValue AccountPublicKey
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/accounts/{address}/keys/{index}"
+	localVarPath = strings.Replace(localVarPath, "{"+"address"+"}", fmt.Sprintf("%v", address), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"index"+"}", fmt.Sprintf("%v", index), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if localVarOptionals != nil && localVarOptionals.BlockHeight.IsSet() {
+		localVarQueryParams.Add("block_height", parameterToString(localVarOptionals.BlockHeight.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Expand.IsSet() {
+		localVarQueryParams.Add("expand", parameterToString(localVarOptionals.Expand.Value(), "csv"))
+	}
+	if localVarOptionals != nil && localVarOptionals.Select_.IsSet() {
+		localVarQueryParams.Add("select", parameterToString(localVarOptionals.Select_.Value(), "csv"))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body: localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v AccountPublicKey
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 400 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 404 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 500 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}

--- a/openapi/go-client-generated/api_blocks.go
+++ b/openapi/go-client-generated/api_blocks.go
@@ -304,3 +304,133 @@ func (a *BlocksApiService) BlocksIdGet(ctx context.Context, id []string, localVa
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
+/*
+BlocksApiService Get Block Payload by Block ID.
+Get a block payload data by the provided block ID.
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param id A block ID.
+ * @param optional nil or *BlocksApiBlocksIdPayloadGetOpts - Optional Parameters:
+     * @param "Expand" (optional.Interface of []string) -  A comma-separated list indicating which properties of the content to expand.
+     * @param "Select_" (optional.Interface of []string) -  A comma-separated list indicating which properties of the content to return.
+@return BlockPayload
+*/
+
+type BlocksApiBlocksIdPayloadGetOpts struct {
+    Expand optional.Interface
+    Select_ optional.Interface
+}
+
+func (a *BlocksApiService) BlocksIdPayloadGet(ctx context.Context, id string, localVarOptionals *BlocksApiBlocksIdPayloadGetOpts) (BlockPayload, *http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Get")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		localVarReturnValue BlockPayload
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/blocks/{id}/payload"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", fmt.Sprintf("%v", id), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if localVarOptionals != nil && localVarOptionals.Expand.IsSet() {
+		localVarQueryParams.Add("expand", parameterToString(localVarOptionals.Expand.Value(), "csv"))
+	}
+	if localVarOptionals != nil && localVarOptionals.Select_.IsSet() {
+		localVarQueryParams.Add("select", parameterToString(localVarOptionals.Select_.Value(), "csv"))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body: localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v BlockPayload
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 400 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 404 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 500 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}

--- a/openapi/go-client-generated/docs/AccountsApi.md
+++ b/openapi/go-client-generated/docs/AccountsApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *https://rest-canary.onflow.org/v1/*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**AccountsAddressGet**](AccountsApi.md#AccountsAddressGet) | **Get** /accounts/{address} | Get an Account By Address
+[**AccountsAddressKeysIndexGet**](AccountsApi.md#AccountsAddressKeysIndexGet) | **Get** /accounts/{address}/keys/{index} | Get an individual Account Key By Address and Index
 
 # **AccountsAddressGet**
 > Account AccountsAddressGet(ctx, address, optional)
@@ -32,6 +33,46 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**Account**](Account.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **AccountsAddressKeysIndexGet**
+> AccountPublicKey AccountsAddressKeysIndexGet(ctx, address, index, optional)
+Get an individual Account Key By Address and Index
+
+Get an account data by provided address in latest \"sealed\" block or by provided block height.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **address** | [**string**](.md)| The address of the account. | 
+  **index** | **string**| The index of the account key. | 
+ **optional** | ***AccountsApiAccountsAddressKeysIndexGetOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a pointer to a AccountsApiAccountsAddressKeysIndexGetOpts struct
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+ **blockHeight** | [**optional.Interface of BlockHeight**](.md)| The block height to query for the account details at the \&quot;sealed\&quot; is used by default. | 
+ **expand** | [**optional.Interface of []string**](string.md)| A comma-separated list indicating which properties of the content to expand. | 
+ **select_** | [**optional.Interface of []string**](string.md)| A comma-separated list indicating which properties of the content to return. | 
+
+### Return type
+
+[**AccountPublicKey**](AccountPublicKey.md)
 
 ### Authorization
 

--- a/openapi/go-client-generated/docs/BlocksApi.md
+++ b/openapi/go-client-generated/docs/BlocksApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**BlocksGet**](BlocksApi.md#BlocksGet) | **Get** /blocks | Gets Blocks by Height
 [**BlocksIdGet**](BlocksApi.md#BlocksIdGet) | **Get** /blocks/{id} | Get Blocks by ID.
+[**BlocksIdPayloadGet**](BlocksApi.md#BlocksIdPayloadGet) | **Get** /blocks/{id}/payload | Get Block Payload by Block ID.
 
 # **BlocksGet**
 > []Block BlocksGet(ctx, optional)
@@ -70,6 +71,43 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**[]Block**](Block.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **BlocksIdPayloadGet**
+> BlockPayload BlocksIdPayloadGet(ctx, id, optional)
+Get Block Payload by Block ID.
+
+Get a block payload data by the provided block ID.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **id** | [**string**](.md)| A block ID. | 
+ **optional** | ***BlocksApiBlocksIdPayloadGetOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a pointer to a BlocksApiBlocksIdPayloadGetOpts struct
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+ **expand** | [**optional.Interface of []string**](string.md)| A comma-separated list indicating which properties of the content to expand. | 
+ **select_** | [**optional.Interface of []string**](string.md)| A comma-separated list indicating which properties of the content to return. | 
+
+### Return type
+
+[**BlockPayload**](BlockPayload.md)
 
 ### Authorization
 


### PR DESCRIPTION
## Description

This PR adds the following (existing) endpoints to the openapi spec that were missed:
* `/blocks/{id}/payload`
* `/accounts/{address}/keys/{index}`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
