### PR TITLE
Update sporks.json

### DIFF
--- a/sporks.json
+++ b/sporks.json
@@ -26,10 +26,10 @@
           }
         },
         "tags": {
-          "flow-go": "v0.32.6-patch.2",
+          "flow-go": "v0.32.9",
           "flow-dps": "v0.32.6-patch.2",
           "cadence": "v0.42.3-patch.2",
-          "docker": "v0.32.6-patch.2"
+          "docker": "v0.32.9"
         },
         "seedNodes": [
           {


### PR DESCRIPTION
The sporks.json mention a docker tag for mainnet24 that is not available publicly. This PR updates it to a version that was built using the same code but with a tag that is publicly available.

The tag is used by any node operator to determine which docker image to run with. Some of the operators require that the image be built from a public repo.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
