### PR TITLE
Change HashQuark to HashKey Cloud

### DIFF
--- a/nodeoperators/NodeOperatorList.md
+++ b/nodeoperators/NodeOperatorList.md
@@ -113,7 +113,7 @@
 | Foundry | Consensus | 56e97c4cd4079caeb97d2a8f8950437107813436d5964f22a1f459eb8cf73a71
 | Foundry | Collection | bd368122b0ccf67ebdd59d7f9b75edfa85106c3af41854c946ad0fa46e5c3ddd
 | Foundry | Verification | e74d0ca7afed2b5bfd612f3c75010adb229d632ca4ab3b77d178ee226d7ec2a2
-| HashQuark | Verification | 55069e7e8926867bee8094bd31786f8f6b65c8c3bde468ae2275f33dc1245dc1
+| HashKey Cloud | Verification | 55069e7e8926867bee8094bd31786f8f6b65c8c3bde468ae2275f33dc1245dc1
 | Huobi | Verification | 6944b7968594f277c4c051d83ced4bab6ed87ed992d831f31ffb6a7b5926e298
 | Lilico | Verification | 3c6519ba8be35e338df7273a895ad3abaeb0c232eb908ee7b05462018c112fe1
 | Metapurse | Collection |da27c0fc2a4fe12c04bd70058252c5a26cfe41485bf6ea6aba1c724b7a07542d

--- a/nodeoperators/nodelist.json
+++ b/nodeoperators/nodelist.json
@@ -2817,7 +2817,7 @@
     },
     {
         "Role": "verification",
-        "Address": "flow.hashquark.io:3569",
+        "Address": "flow.hashkey.cloud:3569",
         "NodeID": "55069e7e8926867bee8094bd31786f8f6b65c8c3bde468ae2275f33dc1245dc1",
         "Stake": 1000,
         "NetworkPubKey": "94aabc1693c8f3a8383b898c93b72b5d3807a69742b45ab629ceea721da60a2c7248fcbe74ecd4de1f1c970bd7e30af0adfb5fd06a1fa8e6cfe1c3c17530b3de",


### PR DESCRIPTION
change node operator name from HashQuark to HashKey Cloud in the nodeoperators/NodeOperatorList.md file, and modify node operator network address in the nodeoperators/nodelist.json file.