### PR TITLE
Add possible template for WG Scrum of Scrums

### DIFF
--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -60,6 +60,8 @@ Cycle Objective(s):
   - Finalized the design, created and estimated epic issues
   - Added details for how to use KVStore for height-coordinated upgrade of Protocol State Machine
 - Draft blog post for Dynamic Protocol State release
+- Resolved mainnet24 [peer scoring incident](https://github.com/dapperlabs/flow-go/issues/6913)
+- Added [comprehensive documentation](https://github.com/onflow/flow-go/pull/5308) for libp2p resource management operators guidance
 
 **This sprint**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -84,6 +84,8 @@ Cycle Objective(s):
 
 - Band Protocol contracts and integration released on testnet
 - Axelar unblocked to wrap up their bridge contracts after ABI.encode/decode() support also released on testnet
+- Upgrade of Flow JVM SDK to support Flow DeFi partners started (@lealobanov)
+- IncrementFi contract 1.0 upgrade on track
 
 
 **This sprint**

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -79,8 +79,8 @@ Cycle Objective(s):
 
 **Done last sprint**
 
-- General description of completed items
-- List of Closed issues
+- Band Protocol contracts and integration released on testnet
+- Axelar unblocked to wrap up their bridge contracts after ABI.encode/decode() support also released on testnet
 
 
 **This sprint**

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -91,7 +91,7 @@ Cycle Objective(s):
 
 **On Hold**
 
-- List of issues on hold
+- N/A
 
 
 **Active Epics**

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -63,8 +63,11 @@ Cycle Objective(s):
 
 **This sprint**
 
-- General description of sprint goal
-- List of issues to be worked on
+- [Design - Sporkless Epoch Fallback Recovery](https://www.notion.so/dapperlabs/Spork-less-Epoch-Fallback-Recovery-Design-II-Epoch-Extensions-a7673e45e9064d12b6b48aa517bd1763?pvs=4) - enabling recovery from EFM via governance multisig and without spork
+  - Review and iteration on latest design
+- Begin implementing KV Store
+
+
 
 
 **On Hold**

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -56,9 +56,10 @@ Cycle Objective(s):
 
 **Done last sprint**
 
-- General description of completed items
-- List of Closed issues
-
+-  [Design - Dynamic Protocol State Key-Value Store](https://www.notion.so/dapperlabs/Protocol-state-key-value-storage-497326ff9cf44ff4a70610a0dad329b3?pvs=4) - generalizing Dynamic Protocol State beyond identity table changes 
+  - Finalized the design, created and estimated epic issues
+  - Added details for how to use KVStore for height-coordinated upgrade of Protocol State Machine
+- Draft blog post for Dynamic Protocol State release
 
 **This sprint**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -93,7 +93,8 @@ Cycle Objective(s):
 
 - Band Protocol contracts and integration released on testnet
 - Axelar unblocked to wrap up their bridge contracts after ABI.encode/decode() support also released on testnet
-- IncrementFi contract 1.0 upgrade on track
+- Started upgrade of Flow JVM SDK to support Flow DeFi partners (@lealobanov)
+- IncrementFi confirmed their Cadence 1.0 upgrade plan is on track
 
 
 **This sprint**

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -1,0 +1,176 @@
+# Team Wins 🎉
+
+- 
+
+### Mainnet Uptime SLO - Last 14 days (DD/MM/YY to DD/MM/YY) - Vishal
+
+|                         | Target | Current Score | Error budget used |
+|:------------------------|:------:|:-------------:|:-----------------:|
+| Collection Finalization | 99.9%   |    100%       |       0%         |
+| Block Finalization      | 99.9%   |    100%       |       0%         |
+| Transaction Execution   | 99.9%   |    100%       |       0%         |
+| Block Sealing           | 99.9%   |    100%       |       0%         |
+| Access API Liveness     | 99.9%   |    100%       |       0%         |
+
+#### Incidents
+- 
+
+### **Cadence and Virtual Machine** Jan
+Objective: 
+
+**Done last sprint**
+
+- 
+
+
+**This sprint**
+
+-
+
+
+**On Hold**
+
+-
+
+
+**Active Epics**
+
+-
+
+---
+
+### **Core Protocol** Jerome
+Objective: 
+
+**Done last sprint**
+
+-
+
+**This sprint**
+
+-
+
+**On Hold**
+
+-
+
+**Active Epics**
+
+-
+
+---
+
+### **DeFi** Jerome
+Objective: 
+
+**Done last sprint**
+
+-
+
+**This sprint**
+
+-
+
+**On Hold**
+
+-
+
+**Active Epics**
+
+-
+
+---
+
+### **User Experience** Greg
+Objective: 
+
+**Done last sprint**
+
+-
+
+**This sprint**
+
+-
+
+**On Hold**
+
+-
+
+**Active Epics**
+
+-
+
+---
+
+### **Wallet** Jeff
+Objective: 
+
+**Done last sprint**
+
+-
+
+**This sprint**
+
+-
+
+**On Hold**
+
+-
+
+**Active Epics**
+
+-
+
+---
+
+
+### **Infra - JP**
+
+**Done last sprint**
+
+**This sprint**
+
+-
+
+---
+
+### **Governance and Tokenomics** Vishal
+Objective: 
+
+**Done last sprint**
+
+-
+
+**This sprint**
+
+-
+
+**On Hold**
+
+-
+
+**Active Epics**
+
+-
+
+---
+
+### FLIPs Tracker - Vishal
+
+|                         | Application | Cadence | Governance | Protocol | Total |  
+|:------------------------|:------:|:-------------:|:-----------------:|:-----------------:|:-----------------:|
+| Drafted     | 8  |    10    |       0          |       6          |        **24**          |
+| Proposed    | 2  |    2     |       2          |       1          |        **7**          |
+| Accepted    | 2  |    1     |       1       |       1          |        **5**          |
+| Rejected    | 0  |    0     |       1       |       0          |        **1**          |
+| Implemented | 1  |    19    |       1       |       0          |        **21**          |
+| Released    | 4  |    0     |       2       |       4          |        **10**          |
+| Total       | **17**  |    **32**    |       **7**       |       **12**          |        **68**          |
+
+- 
+  
+### Key Release Dates & Breaking Changes
+
+- Next Mainnet/Testnet network upgrade (spork):
+- Next Mainnet/Testnet HCU:
+- End of Cycle:

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -91,6 +91,7 @@ Cycle Objective(s):
 **This sprint**
 
 - Complete Band Protocol docs and examples and publish to community. This enables broader testing on testnet
+- USDC contracts update to Cadence 1.0 starting (@joshuahannan)
 
 **On Hold**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -1,4 +1,6 @@
-# Team Wins 🎉
+# Overview
+
+ ### Team Wins 🎉
 
 - 
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -1,6 +1,8 @@
 # Overview
 
  ### Team Wins 🎉
+ 
+ * ABI.encode/decode() functional subset of EVM work was deployed to testnet to unblock Axelar integration
 
 - 
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -94,8 +94,8 @@ Cycle Objective(s):
 
 **Active Epics**
 
-- Main epics that are being tackled, and currently active for this working group
-
+- Launch oracle network feeds on Flow 
+- Launch second token bridge on Flow
 ---
 
 ### **User Experience** Greg

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -51,6 +51,9 @@ Cycle Objective(s):
 ### **Core Protocol** Jerome
 Cycle Objective(s): 
 
+* Continue with adding BFT mitigations to enable 10 permissionless ANs
+* Continue design of Dynamic Protocol 
+
 **Done last sprint**
 
 - General description of completed items

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -109,8 +109,9 @@ Cycle Objective(s):
 
 **Active Epics**
 
-- Launch oracle network feeds on Flow 
-- Launch second token bridge on Flow
+- Establish Defi/Liquidity infrastructure for Cadence 1.0 update
+- Ensure Flow has best-in-class on- and off-ramps for USDC liquidity across DeFi ecosystem
+- Expand Flow DeFi ecosystem primitives and protocols
 ---
 
 ### **User Experience** Greg

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -2,7 +2,7 @@
 
 - 
 
-### Mainnet Uptime SLO - Last 14 days (DD/MM/YY to DD/MM/YY) - Vishal
+### Mainnet Uptime - Last 14 days (DD/MM/YY to DD/MM/YY) - Vishal
 
 |                         | Target | Current Score | Error budget used |
 |:------------------------|:------:|:-------------:|:-----------------:|
@@ -20,22 +20,24 @@ Objective:
 
 **Done last sprint**
 
-- 
+- General description of completed items
+- List of Closed issues
 
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
 
 
 **On Hold**
 
--
+- List of issues on hold
 
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
@@ -44,19 +46,24 @@ Objective:
 
 **Done last sprint**
 
--
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
--
+- List of issues on hold
+
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
@@ -65,19 +72,24 @@ Objective:
 
 **Done last sprint**
 
--
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
--
+- List of issues on hold
+
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
@@ -86,19 +98,24 @@ Objective:
 
 **Done last sprint**
 
--
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
--
+- List of issues on hold
+
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
@@ -107,30 +124,51 @@ Objective:
 
 **Done last sprint**
 
--
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
--
+- List of issues on hold
+
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
 
 ### **Infra - JP**
+Objective: 
 
 **Done last sprint**
 
+- General description of completed items
+- List of Closed issues
+
+
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
+
+**On Hold**
+
+- List of issues on hold
+
+
+**Active Epics**
+
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 
@@ -139,19 +177,24 @@ Objective:
 
 **Done last sprint**
 
--
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
--
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
--
+- List of issues on hold
+
 
 **Active Epics**
 
--
+- Main epics that are being tackled, and currently active for this working group
 
 ---
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -62,15 +62,21 @@ Cycle Objective(s):
 - Draft blog post for Dynamic Protocol State release
 - Resolved mainnet24 [peer scoring incident](https://github.com/dapperlabs/flow-go/issues/6913)
 - Added [comprehensive documentation](https://github.com/onflow/flow-go/pull/5308) for libp2p resource management operators guidance
+- Data Availability
+  - Added support for error trees in FVM
+  - Fixed race condition in local event streaming
 
 **This sprint**
 
 - [Design - Sporkless Epoch Fallback Recovery](https://www.notion.so/dapperlabs/Spork-less-Epoch-Fallback-Recovery-Design-II-Epoch-Extensions-a7673e45e9064d12b6b48aa517bd1763?pvs=4) - enabling recovery from EFM via governance multisig and without spork
   - Review and iteration on latest design
 - Begin implementing KV Store
-
-
-
+- Create [GossipSub forensics dashboard](https://github.com/dapperlabs/flow-go/issues/6933)
+- Identify remaining technical gaps in the GH issues for the upcoming OKR
+- Implement incident management runbook for networking layer
+- [upgrade libp2p version to v0.32.0](https://github.com/onflow/flow-go/issues/4934)
+- Fix Access connection cache race condition
+- Add register cache for script executions
 
 **On Hold**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -16,7 +16,7 @@
 - 
 
 ### **Cadence and Virtual Machine** Jan
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -42,7 +42,7 @@ Objective:
 ---
 
 ### **Core Protocol** Jerome
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -68,7 +68,7 @@ Objective:
 ---
 
 ### **DeFi** Jerome
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -94,7 +94,7 @@ Objective:
 ---
 
 ### **User Experience** Greg
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -120,7 +120,7 @@ Objective:
 ---
 
 ### **Wallet** Jeff
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -147,7 +147,7 @@ Objective:
 
 
 ### **Infra - JP**
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 
@@ -173,7 +173,7 @@ Objective:
 ---
 
 ### **Governance and Tokenomics** Vishal
-Objective: 
+Cycle Objective(s): 
 
 **Done last sprint**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -77,7 +77,12 @@ Cycle Objective(s):
 
 **Active Epics**
 
-- Main epics that are being tackled, and currently active for this working group
+- Reinforcing Flow’s commitment to full protocol autonomy and scalability
+- Improve network performance
+- Improve network availability 
+- Simplify community contributions to core protocol and maintainability
+- Improve network reliability and data availability for dApp developers
+- Data-driven Prioritization and Scaling Engineering
 
 ---
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -17,8 +17,30 @@
 | Access API Liveness     | 99.9%   |    100%       |       0%         |
 
 #### Incidents
+
 - 
 
+### FLIPs Tracker - Kshitij
+
+|                         | Application | Cadence | Governance | Protocol | Total |  
+|:------------------------|:------:|:-------------:|:-----------------:|:-----------------:|:-----------------:|
+| Drafted     | 8  |    10    |       0          |       6          |        **24**          |
+| Proposed    | 2  |    2     |       2          |       1          |        **7**          |
+| Accepted    | 2  |    1     |       1       |       1          |        **5**          |
+| Rejected    | 0  |    0     |       1       |       0          |        **1**          |
+| Implemented | 1  |    19    |       1       |       0          |        **21**          |
+| Released    | 4  |    0     |       2       |       4          |        **10**          |
+| Total       | **17**  |    **32**    |       **7**       |       **12**          |        **68**          |
+
+- 
+  
+### Key Release Dates & Breaking Changes
+
+- Next Mainnet/Testnet network upgrade (spork):
+- Next Mainnet/Testnet HCU:
+- End of Cycle:
+
+---
 
 # Working Group Updates
 
@@ -51,32 +73,17 @@ Cycle Objective(s):
 ### **Core Protocol** Jerome
 Cycle Objective(s): 
 
-* Continue with adding BFT mitigations to enable 10 permissionless ANs
-* Continue design of Dynamic Protocol 
-
 **Done last sprint**
 
--  [Design - Dynamic Protocol State Key-Value Store](https://www.notion.so/dapperlabs/Protocol-state-key-value-storage-497326ff9cf44ff4a70610a0dad329b3?pvs=4) - generalizing Dynamic Protocol State beyond identity table changes 
-  - Finalized the design, created and estimated epic issues
-  - Added details for how to use KVStore for height-coordinated upgrade of Protocol State Machine
-- Draft blog post for Dynamic Protocol State release
-- Resolved mainnet24 [peer scoring incident](https://github.com/dapperlabs/flow-go/issues/6913)
-- Added [comprehensive documentation](https://github.com/onflow/flow-go/pull/5308) for libp2p resource management operators guidance
-- Data Availability
-  - Added support for error trees in FVM
-  - Fixed race condition in local event streaming
+- General description of completed items
+- List of Closed issues
+
 
 **This sprint**
 
-- [Design - Sporkless Epoch Fallback Recovery](https://www.notion.so/dapperlabs/Spork-less-Epoch-Fallback-Recovery-Design-II-Epoch-Extensions-a7673e45e9064d12b6b48aa517bd1763?pvs=4) - enabling recovery from EFM via governance multisig and without spork
-  - Review and iteration on latest design
-- Begin implementing KV Store
-- Create [GossipSub forensics dashboard](https://github.com/dapperlabs/flow-go/issues/6933)
-- Identify remaining technical gaps in the GH issues for the upcoming OKR
-- Implement incident management runbook for networking layer
-- [upgrade libp2p version to v0.32.0](https://github.com/onflow/flow-go/issues/4934)
-- Fix Access connection cache race condition
-- Add register cache for script executions
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
@@ -85,42 +92,33 @@ Cycle Objective(s):
 
 **Active Epics**
 
-- Reinforcing Flow’s commitment to full protocol autonomy and scalability
-- Improve network performance
-- Improve network availability 
-- Simplify community contributions to core protocol and maintainability
-- Improve network reliability and data availability for dApp developers
-- Data-driven Prioritization and Scaling Engineering
+- Main epics that are being tackled, and currently active for this working group
 
----
 
 ### **DeFi** Jerome
 Cycle Objective(s): 
 
 **Done last sprint**
 
-- Band Protocol contracts and integration released on testnet
-- Axelar unblocked to wrap up their bridge contracts after ABI.encode/decode() support also released on testnet
-- Started upgrade of Flow JVM SDK to support Flow DeFi partners (@lealobanov)
-- IncrementFi confirmed their Cadence 1.0 upgrade plan is on track
+- General description of completed items
+- List of Closed issues
 
 
 **This sprint**
 
-- Complete Band Protocol docs and examples and publish to community. This enables broader testing on testnet
-- USDC contracts update to Cadence 1.0 starting (@joshuahannan)
+- General description of sprint goal
+- List of issues to be worked on
+
 
 **On Hold**
 
-- N/A
+- List of issues on hold
 
 
 **Active Epics**
 
-- Establish Defi/Liquidity infrastructure for Cadence 1.0 update
-- Ensure Flow has best-in-class on- and off-ramps for USDC liquidity across DeFi ecosystem
-- Expand Flow DeFi ecosystem primitives and protocols
----
+- Main epics that are being tackled, and currently active for this working group
+
 
 ### **User Experience** Greg
 Cycle Objective(s): 
@@ -224,25 +222,3 @@ Cycle Objective(s):
 **Active Epics**
 
 - Main epics that are being tackled, and currently active for this working group
-
----
-
-### FLIPs Tracker - Kshitij
-
-|                         | Application | Cadence | Governance | Protocol | Total |  
-|:------------------------|:------:|:-------------:|:-----------------:|:-----------------:|:-----------------:|
-| Drafted     | 8  |    10    |       0          |       6          |        **24**          |
-| Proposed    | 2  |    2     |       2          |       1          |        **7**          |
-| Accepted    | 2  |    1     |       1       |       1          |        **5**          |
-| Rejected    | 0  |    0     |       1       |       0          |        **1**          |
-| Implemented | 1  |    19    |       1       |       0          |        **21**          |
-| Released    | 4  |    0     |       2       |       4          |        **10**          |
-| Total       | **17**  |    **32**    |       **7**       |       **12**          |        **68**          |
-
-- 
-  
-### Key Release Dates & Breaking Changes
-
-- Next Mainnet/Testnet network upgrade (spork):
-- Next Mainnet/Testnet HCU:
-- End of Cycle:

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -93,7 +93,6 @@ Cycle Objective(s):
 
 - Band Protocol contracts and integration released on testnet
 - Axelar unblocked to wrap up their bridge contracts after ABI.encode/decode() support also released on testnet
-- Upgrade of Flow JVM SDK to support Flow DeFi partners started (@lealobanov)
 - IncrementFi contract 1.0 upgrade on track
 
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -219,7 +219,7 @@ Cycle Objective(s):
 
 ---
 
-### FLIPs Tracker - Vishal
+### FLIPs Tracker - Kshitij
 
 |                         | Application | Cadence | Governance | Protocol | Total |  
 |:------------------------|:------:|:-------------:|:-----------------:|:-----------------:|:-----------------:|

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -85,9 +85,7 @@ Cycle Objective(s):
 
 **This sprint**
 
-- General description of sprint goal
-- List of issues to be worked on
-
+- Complete Band Protocol docs and examples and publish to community. This enables broader testing on testnet
 
 **On Hold**
 

--- a/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
+++ b/agendas/2024/sprint-kickoff/YYYY-MM-DD-Flow-Sprint-Kickoff-Template.md
@@ -19,6 +19,9 @@
 #### Incidents
 - 
 
+
+# Working Group Updates
+
 ### **Cadence and Virtual Machine** Jan
 Cycle Objective(s): 
 


### PR DESCRIPTION
In the interest of bringing more clarity of what's happening across the team on Flow, we are aiming to consolidate the sprint kick-off across all working groups on Flow. This will help represent all engineering work being tackled by the the core Flow Foundation engineers, and provide clarity both across WGs and with external on-lookers.

The idea is that each WG has their own section, with the following format:

---

Objective: 

**Done last sprint**

- General description of completed items
- List of Closed issues


**This sprint**

- General description of sprint goal
- List of issues to be worked on


**On Hold**

- List of issues on hold


**Active Epics**

- Main epics that are being tackled, and currently active for this working group

---

Additionally, there are four general sections, being

- Wins
- Mainnet Uptime
- FLIPs Tracker
- Key Release Dates