### PR TITLE
JVM Protobuf Updates

### DIFF
--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -25,7 +25,10 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Checkout code
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v3
+
+      - name: Change to protobuf directory
+        run: cd protobuf
 
       - name: Setup Java
         uses: actions/setup-java@v2 

--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -1,4 +1,4 @@
-name: Manually Publish Release
+name: Manually Publish Release - JVM Protobuf
 on:
   workflow_dispatch:
     branches:

--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -1,0 +1,63 @@
+name: Manually Publish Release
+on:
+  workflow_dispatch:
+    branches:
+      - master
+jobs:
+  build:
+    name: Manually publish release
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+    #services:
+    #  flow-emulator:
+    #    image: gcr.io/flow-container-registry/emulator
+    #    env:
+    #      FLOW_VERBOSE: true
+    #      FLOW_PORT: 3569
+    #      FLOW_INTERVAL: 5s
+    #      FLOW_PERSIST: false
+    #    ports:
+    #      - 3569:3569
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - name: Checkout code
+        uses: actions/checkout@v3 
+
+      - name: Setup Java
+        uses: actions/setup-java@v2 
+        with:
+          java-version: '21'
+          java-package: jdk
+          distribution: 'adopt'
+
+      - name: Install flow emulator
+        run: sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
+
+      - name: Make gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        id: build
+        run: ./gradlew --warning-mode all check build -x test -x integrationTest
+
+      - name: Publish release
+        env:
+          JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+          ORG_GRADLE_PROJECT_mavenCentralUsername:  '${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}'
+          ORG_GRADLE_PROJECT_mavenCentralPassword:  '${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}'
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
+
+        run: |
+          if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
+          then
+            exit 0;
+          fi
+          ./gradlew \
+            -Psigning.key="${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}" \
+            -Psigning.password="${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}" \
+            publishAndReleaseToMavenCentral --no-configuration-cache

--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -38,11 +38,11 @@ jobs:
           distribution: 'adopt'
 
       - name: Make gradle executable
-        run: chmod +x ./gradlew
+        run: chmod +x ./protobuf/gradlew
 
       - name: Build
         id: build
-        run: ./gradlew --warning-mode all check build
+        run: cd protobuf && ./gradlew --warning-mode all check build
 
       - name: Publish release
         env:
@@ -53,6 +53,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
 
         run: |
+          cd protobuf
           if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
           then
             exit 0;

--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Change to protobuf directory
-        run: cd protobuf
-
       - name: Setup Java
         uses: actions/setup-java@v2 
         with:

--- a/.github/workflows/ci-manual-publish-jvm-release.yml
+++ b/.github/workflows/ci-manual-publish-jvm-release.yml
@@ -37,15 +37,12 @@ jobs:
           java-package: jdk
           distribution: 'adopt'
 
-      - name: Install flow emulator
-        run: sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
-
       - name: Make gradle executable
         run: chmod +x ./gradlew
 
       - name: Build
         id: build
-        run: ./gradlew --warning-mode all check build -x test -x integrationTest
+        run: ./gradlew --warning-mode all check build
 
       - name: Publish release
         env:

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -38,11 +38,11 @@ jobs:
           distribution: 'adopt'
 
       - name: Make gradle executable
-        run: chmod +x ./gradlew
+        run: chmod +x ./protobuf/gradlew
 
       - name: Build
         id: build
-        run: ./gradlew --warning-mode all check build
+        run: cd protobuf && ./gradlew --warning-mode all check build
 
       - name: Publish snapshot
         env:
@@ -53,6 +53,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
 
         run: |
+          cd protobuf
           if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
           then
             exit 0;

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -25,7 +25,10 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Checkout code
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v3
+
+      - name: Change to protobuf directory
+        run: cd protobuf
 
       - name: Setup Java
         uses: actions/setup-java@v2 

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build
         id: build
-        run: ./gradlew --warning-mode all check build -x test -x integrationTest
+        run: ./gradlew --warning-mode all check build
 
       - name: Publish snapshot
         env:

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Change to protobuf directory
-        run: cd protobuf
-
       - name: Setup Java
         uses: actions/setup-java@v2 
         with:

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -1,0 +1,60 @@
+name: Manually Publish Snapshot
+on:
+  workflow_dispatch:
+    branches:
+      - master
+jobs:
+  build:
+    name: Manually publish snapshot
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+    #services:
+    #  flow-emulator:
+    #    image: gcr.io/flow-container-registry/emulator
+    #    env:
+    #      FLOW_VERBOSE: true
+    #      FLOW_PORT: 3569
+    #      FLOW_INTERVAL: 5s
+    #      FLOW_PERSIST: false
+    #    ports:
+    #      - 3569:3569
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - name: Checkout code
+        uses: actions/checkout@v3 
+
+      - name: Setup Java
+        uses: actions/setup-java@v2 
+        with:
+          java-version: '21'
+          java-package: jdk
+          distribution: 'adopt'
+
+      - name: Make gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        id: build
+        run: ./gradlew --warning-mode all check build -x test -x integrationTest
+
+      - name: Publish snapshot
+        env:
+          JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+          ORG_GRADLE_PROJECT_mavenCentralUsername:  '${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}'
+          ORG_GRADLE_PROJECT_mavenCentralPassword:  '${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}'
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
+
+        run: |
+          if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
+          then
+            exit 0;
+          fi
+          ./gradlew \
+            -Psigning.key="${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}" \
+            -Psigning.password="${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}" \
+            publishToMavenCentral --no-configuration-cache

--- a/.github/workflows/ci-manual-publish-jvm-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-jvm-snapshot.yml
@@ -1,4 +1,4 @@
-name: Manually Publish Snapshot
+name: Manually Publish Snapshot - JVM Protobuf
 on:
   workflow_dispatch:
     branches:

--- a/.github/workflows/ci-pull-request-jvm-protobuf.yml
+++ b/.github/workflows/ci-pull-request-jvm-protobuf.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Change to protobuf directory
-        run: cd ./protobuf
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
@@ -32,7 +29,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Make gradle executable
-        run: chmod +x ./gradlew
+        run: chmod +x ./protobuf/gradlew
 
       - name: Build
         id: build

--- a/.github/workflows/ci-pull-request-jvm-protobuf.yml
+++ b/.github/workflows/ci-pull-request-jvm-protobuf.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Build
         id: build
-        run: ./gradlew --warning-mode all check build
+        run: cd protobuf && ./gradlew --warning-mode all check build

--- a/.github/workflows/ci-pull-request-jvm-protobuf.yml
+++ b/.github/workflows/ci-pull-request-jvm-protobuf.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Change to protobuf directory
-        run: cd protobuf
+        run: cd ./protobuf
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/ci-pull-request-jvm-protobuf.yml
+++ b/.github/workflows/ci-pull-request-jvm-protobuf.yml
@@ -1,4 +1,4 @@
-name: Build Pull Request
+name: Build Pull Request - JVM Protobuf
 on: pull_request
 
 jobs:

--- a/.github/workflows/ci-pull-request-jvm-protobuf.yml
+++ b/.github/workflows/ci-pull-request-jvm-protobuf.yml
@@ -1,0 +1,39 @@
+name: Build Pull Request
+on: pull_request
+
+jobs:
+  build:
+    name: Build pull request
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+    #services:
+    #  flow-emulator:
+    #    image: gcr.io/flow-container-registry/emulator
+    #    env:
+    #      FLOW_VERBOSE: true
+    #      FLOW_PORT: 3569
+    #      FLOW_INTERVAL: 5s
+    #      FLOW_PERSIST: false
+    #    ports:
+    #      - 3569:3569
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Change to protobuf directory
+        run: cd protobuf
+
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          java-package: jdk
+          distribution: 'adopt'
+
+      - name: Make gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        id: build
+        run: ./gradlew --warning-mode all check build

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -27,12 +27,19 @@ JVM support is in the alpha stage; many steps require manual intervention.
 
 `./gradlew generateProto` compiles Protobuf files into local Java classes.
 
-### Publishing
+### Publishing with GitHub Actions
 
-`./gradlew publishToSonatype` prepares and publishes compiled classes into JAR and uploads to OSSRH staging repository.
+The "com.vanniktech.maven.publish" plugin is used to automate Maven releases for JVM protobuf generation. More information on the release process can be found here [here](https://vanniktech.github.io/gradle-maven-publish-plugin/central/).
 
-This requires signing artifacts which is done by [Signing Gradle plugin](https://docs.gradle.org/current/userguide/signing_plugin.html) - it requires
-external configuration and appropriate GPG Keys. Please refer to plugin and [OSSRH](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
-documentation.
-Uploading to staging repo requires an approved Sonatype account. Please refer to [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin)
-documentation how to provide credentials.
+There are two GitHub Actions configured to run on the master branch:
+
+- SNAPSHOT: On every commit to the `master` branch a build is performed and if successful it is deployed as a snapshot version.
+- RELEASE: Whenever a tag is created with the pattern of `vXXX` a version with the name XXX is built and if successful deployed as a release version.
+
+The following GitHub repository secrets configure these actions:
+
+- `FLOW_JVM_SDK_CICD_PUBLISH_ENABLED`: (optional) Must be `true` for the publishing of artifacts to happen (defaults to `false`)
+- `FLOW_JVM_SDK_SIGNING_KEY`: (required if publish enabled) ascii armored version of the pgp key for signing releases
+- `FLOW_JVM_SDK_SIGNING_PASSWORD`: (required if publish enabled) password to the pgp key
+- `FLOW_JVM_SDK_SONATYPE_USERNAME`: (required if publish enabled) sonatype username
+- `FLOW_JVM_SDK_SONATYPE_PASSWORD`: (required if publish enabled) sonatype password

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -44,6 +44,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_20
 }
 
+tasks.named("generateProto") {
+    dependsOn(tasks.named("processResources"))
+}
+
 tasks {
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.DEFAULT, true)

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -1,16 +1,40 @@
 import com.google.protobuf.gradle.*
+import com.vanniktech.maven.publish.SonatypeHost
 
+fun getProp(name: String, defaultValue: String? = null): String? {
+    return project.findProperty("flow.$name")?.toString()?.trim()?.ifBlank { null }
+            ?: project.findProperty(name)?.toString()?.trim()?.ifBlank { null }
+            ?: defaultValue
+}
+
+// configuration variables
+val defaultGroupId = "org.onflow"
+val defaultVersion = "1.0.0"
+
+group = getProp("groupId", defaultGroupId)!!
+version = when {
+    getProp("version") !in setOf("unspecified", null) -> { getProp("version")!! }
+    getProp("snapshotDate") != null -> { "${defaultVersion.replace("-SNAPSHOT", "")}.${getProp("snapshotDate")!!}-SNAPSHOT" }
+    else -> { defaultVersion }
+}
 
 plugins {
     id("com.google.protobuf") version "0.8.15"
+    kotlin("jvm") version "1.9.22"
     `java-library`
     `maven-publish`
     signing
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
+    id ("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val protobufVersion = "3.14.0"
 val grpcVersion = "1.35.0"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_20
+    targetCompatibility = JavaVersion.VERSION_20
+}
 
 protobuf {
     protoc {
@@ -44,40 +68,44 @@ nexusPublishing {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.DEFAULT, true)
 
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                name.set(project.name)
+    coordinates(group.toString(), "flow-jvm-sdk", version.toString())
+
+    signAllPublications()
+
+    pom {
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        name.set(project.name)
+        url.set("https://onflow.org")
+        description.set("The Flow Blockchain")
+        scm {
+            url.set("https://github.com/onflow/flow")
+            connection.set("scm:git:git@github.com/onflow/flow.git")
+            developerConnection.set("scm:git:git@github.com/onflow/flow.git")
+        }
+        developers {
+            developer {
+                name.set("Flow Developers")
                 url.set("https://onflow.org")
-                description.set("The Flow Blockchain")
-                scm {
-                    url.set("https://github.com/onflow/flow")
-                    connection.set("scm:git:git@github.com/onflow/flow.git")
-                    developerConnection.set("scm:git:git@github.com/onflow/flow.git")
-                }
-                developers {
-                    developer {
-                        name.set("Flow Developers")
-                        url.set("https://onflow.org")
-                    }
-                }
             }
         }
     }
 }
 
 signing {
-    useGpgCmd() //use gpg2
-    sign(publishing.publications["mavenJava"])
+    if (getProp("signing.key") != null) {
+        useInMemoryPgpKeys(getProp("signing.key"), getProp("signing.password"))
+    } else {
+        useGpgCmd()
+    }
+    sign(publishing.publications)
 }
 
 sourceSets {
@@ -97,16 +125,7 @@ java {
     withSourcesJar()
 }
 
-tasks.compileJava {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
-}
-
 repositories {
     mavenCentral()
 }
 
-group = "org.onflow"
-
-// TODO - grab version from Git
-version = "0.21"

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -48,7 +48,7 @@ tasks {
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.DEFAULT, true)
 
-        coordinates(group.toString(), "flow-jvm-sdk", version.toString())
+        coordinates(group.toString(), "flow", version.toString())
 
         signAllPublications()
 

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -19,7 +19,7 @@ version = when {
 }
 
 plugins {
-    id("com.google.protobuf") version "0.8.15"
+    id("com.google.protobuf") version "0.9.4"
     kotlin("jvm") version "1.9.22"
     `java-library`
     `maven-publish`
@@ -31,9 +31,50 @@ plugins {
 val protobufVersion = "3.14.0"
 val grpcVersion = "1.35.0"
 
+dependencies {
+    api("com.google.protobuf:protobuf-java:$protobufVersion")
+    api("io.grpc:grpc-netty-shaded:$grpcVersion")
+    api("io.grpc:grpc-protobuf:$grpcVersion")
+    api("io.grpc:grpc-stub:$grpcVersion")
+    api("javax.annotation:javax.annotation-api:1.3.2")
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_20
     targetCompatibility = JavaVersion.VERSION_20
+}
+
+tasks {
+    mavenPublishing {
+        publishToMavenCentral(SonatypeHost.DEFAULT, true)
+
+        coordinates(group.toString(), "flow-jvm-sdk", version.toString())
+
+        signAllPublications()
+
+        pom {
+            licenses {
+                license {
+                    name.set("The Apache License, Version 2.0")
+                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                }
+            }
+            name.set(project.name)
+            url.set("https://onflow.org")
+            description.set("The Flow Blockchain")
+            scm {
+                url.set("https://github.com/onflow/flow")
+                connection.set("scm:git:git@github.com/onflow/flow.git")
+                developerConnection.set("scm:git:git@github.com/onflow/flow.git")
+            }
+            developers {
+                developer {
+                    name.set("Flow Developers")
+                    url.set("https://onflow.org")
+                }
+            }
+        }
+    }
 }
 
 protobuf {
@@ -49,51 +90,6 @@ protobuf {
         all().forEach {
             it.plugins {
                 id("grpc")
-            }
-        }
-    }
-}
-
-dependencies {
-    api("com.google.protobuf:protobuf-java:$protobufVersion")
-    api("io.grpc:grpc-netty-shaded:$grpcVersion")
-    api("io.grpc:grpc-protobuf:$grpcVersion")
-    api("io.grpc:grpc-stub:$grpcVersion")
-    api("javax.annotation:javax.annotation-api:1.3.2")
-}
-
-nexusPublishing {
-    repositories {
-        sonatype()
-    }
-}
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.DEFAULT, true)
-
-    coordinates(group.toString(), "flow-jvm-sdk", version.toString())
-
-    signAllPublications()
-
-    pom {
-        licenses {
-            license {
-                name.set("The Apache License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-            }
-        }
-        name.set(project.name)
-        url.set("https://onflow.org")
-        description.set("The Flow Blockchain")
-        scm {
-            url.set("https://github.com/onflow/flow")
-            connection.set("scm:git:git@github.com/onflow/flow.git")
-            developerConnection.set("scm:git:git@github.com/onflow/flow.git")
-        }
-        developers {
-            developer {
-                name.set("Flow Developers")
-                url.set("https://onflow.org")
             }
         }
     }

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -46,6 +46,7 @@ java {
 
 tasks.named("generateProto") {
     dependsOn(tasks.named("processResources"))
+    dependsOn(tasks.named("extractIncludeTestProto"))
 }
 
 tasks {

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -47,6 +47,7 @@ java {
 tasks.named("generateProto") {
     dependsOn(tasks.named("processResources"))
     dependsOn(tasks.named("extractIncludeTestProto"))
+    dependsOn(tasks.named("extractTestProto"))
 }
 
 tasks {

--- a/protobuf/gradle/wrapper/gradle-wrapper.properties
+++ b/protobuf/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION


## Description

- Bumped Gradle, Kotlin, and other dependency versions to latest as the current setup is 3+ years old
- Added CICD and signing tasks to build.gradle to use the same flow we currently have setup on JVM SDK
- Added 2 workflows for GH actions to a) manually publish a snapshot and b) manually publish a release to Maven from the master branch

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
