### PR TITLE
Fix CodeQL workflows: use go-version instead of go-version-file

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-            go-version-file: ./go.mod
+            go-version: '1.25.0'
 
      # - name: set credentials for private repos
      #   run: rm -f ~/.gitconfig && git config --global url.https://$ORG_READER_USERNAME:$ORG_READER_PAT@github.com/.insteadOf https://github.com/ && cat ~/.gitconfig

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-            go-version-file: ./go.mod
+            go-version: '1.25.0'
 
      # - name: set credentials for private repos
      #   run: rm -f ~/.gitconfig && git config --global url.https://$ORG_READER_USERNAME:$ORG_READER_PAT@github.com/.insteadOf https://github.com/ && cat ~/.gitconfig


### PR DESCRIPTION
## Security
- Changed from go-version-file: ./go.mod to go-version: '1.25.0'
- Fixes error: The specified go version file at: ./go.mod does not exist
- Matches Go version used in flow-go repository